### PR TITLE
Refactor rule creation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `replication_registry` module into `registry`.
 - Rename `IntoComponentRule::register_component` to `IntoComponentRule::into_rule` and move it to the `shared::replication::rules::component` module.
 - Replace `IntoReplicationRule` with `IntoComponentRules`, which returns only `Vec<ComponentRule>`.
-- Replace `ReplicationBundle` with `BundleRules`, which returns only `Vec<ComponentRule>` and uses an associated constant to customzie the priority.
+- Replace `ReplicationBundle` with `BundleRules`, which returns only `Vec<ComponentRule>` and uses an associated constant to customize the priority.
 
 ## Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `replicon_channels` module into `channels`.
 - Rename `replication_rules` module into `rules`.
 - Rename `replication_registry` module into `registry`.
+- Rename `IntoComponentRule::register_component` to `IntoComponentRule::into_rule` and move it to the `shared::replication::rules::component` module.
+- Replace `IntoReplicationRule` with `IntoComponentRules`, which returns only `Vec<ComponentRule>`.
+- Replace `ReplicationBundle` with `BundleRules`, which returns only `Vec<ComponentRule>` and uses an associated constant to customzie the priority.
 
 ## Removed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -660,7 +660,7 @@ pub mod prelude {
                 Replicated,
                 command_markers::AppMarkerExt,
                 registry::rule_fns::RuleFns,
-                rules::{AppRuleExt, SendRate},
+                rules::{AppRuleExt, component::SendRate},
             },
             replicon_tick::RepliconTick,
         },

--- a/src/server.rs
+++ b/src/server.rs
@@ -32,7 +32,7 @@ use crate::{
                 ReplicationRegistry, component_fns::ComponentFns, ctx::SerializeCtx,
                 rule_fns::UntypedRuleFns,
             },
-            rules::{ComponentRule, ReplicationRules},
+            rules::{ReplicationRules, component::ComponentRule},
             track_mutate_messages::TrackMutateMessages,
         },
     },

--- a/src/server/server_world.rs
+++ b/src/server/server_world.rs
@@ -14,7 +14,7 @@ use log::{debug, trace};
 
 use crate::{
     prelude::*,
-    shared::replication::rules::{ComponentRule, ReplicationRules},
+    shared::replication::rules::{ReplicationRules, component::ComponentRule},
 };
 
 /// A [`SystemParam`] that wraps [`World`], but provides access only for replicated components.

--- a/src/shared/replication/rules.rs
+++ b/src/shared/replication/rules.rs
@@ -46,76 +46,6 @@ pub trait AppRuleExt {
     }
 
     /**
-    Defines a [`ReplicationRule`] for a bundle.
-
-    Implemented for tuples of components. Use it to conveniently create a rule with
-    default ser/de functions and [`SendRate::EveryTick`] for all components.
-    To customize this, use [`Self::replicate_with`].
-
-    Can also be implemented manually for user-defined bundles.
-
-    # Examples
-
-    ```
-    use bevy::prelude::*;
-    use bevy_replicon::{
-        bytes::Bytes,
-        shared::replication::{
-            registry::{
-                ctx::{SerializeCtx, WriteCtx},
-                ReplicationRegistry,
-            },
-            rules::component::{BundleRules, ComponentRule},
-        },
-        prelude::*,
-    };
-    use serde::{Deserialize, Serialize};
-
-    # let mut app = App::new();
-    # app.add_plugins(RepliconPlugins);
-    app.replicate_bundle::<(Name, City)>() // Tuple of components is also a bundle!
-        .replicate_bundle::<PlayerBundle>();
-
-    #[derive(Component, Deserialize, Serialize)]
-    struct City;
-
-    #[derive(Bundle)]
-    struct PlayerBundle {
-        transform: Transform,
-        player: Player,
-    }
-
-    #[derive(Component, Deserialize, Serialize)]
-    struct Player;
-
-    impl BundleRules for PlayerBundle {
-        fn component_rules(world: &mut World, registry: &mut ReplicationRegistry) -> Vec<ComponentRule> {
-            // Customize serlialization to serialize only `translation`.
-            let (transform_id, transform_fns_id) = registry.register_rule_fns(
-                world,
-                RuleFns::new(serialize_translation, deserialize_translation),
-            );
-            let transform = ComponentRule::new(transform_id, transform_fns_id);
-
-            // Serialize `player` as usual.
-            let (player_id, player_fns_id) = registry.register_rule_fns(world, RuleFns::<Player>::default());
-            let player = ComponentRule::new(player_id, player_fns_id);
-
-            // We skip `replication` registration since it's a special component.
-            // It's automatically inserted on clients after replication and
-            // deserialization from scenes.
-
-            vec![transform, player]
-        }
-    }
-
-    # fn serialize_translation(_: &SerializeCtx, _: &Transform, _: &mut Vec<u8>) -> Result<()> { unimplemented!() }
-    # fn deserialize_translation(_: &mut WriteCtx, _: &mut Bytes) -> Result<Transform> { unimplemented!() }
-    ```
-    **/
-    fn replicate_bundle<B: BundleRules>(&mut self) -> &mut Self;
-
-    /**
     Defines a customizable [`ReplicationRule`].
 
     Can be used to customize how a component is passed over the network, or
@@ -420,6 +350,76 @@ pub trait AppRuleExt {
         priority: usize,
         component_rules: R,
     ) -> &mut Self;
+
+    /**
+    Defines a [`ReplicationRule`] for a bundle.
+
+    Implemented for tuples of components. Use it to conveniently create a rule with
+    default ser/de functions and [`SendRate::EveryTick`] for all components.
+    To customize this, use [`Self::replicate_with`].
+
+    Can also be implemented manually for user-defined bundles.
+
+    # Examples
+
+    ```
+    use bevy::prelude::*;
+    use bevy_replicon::{
+        bytes::Bytes,
+        shared::replication::{
+            registry::{
+                ctx::{SerializeCtx, WriteCtx},
+                ReplicationRegistry,
+            },
+            rules::component::{BundleRules, ComponentRule},
+        },
+        prelude::*,
+    };
+    use serde::{Deserialize, Serialize};
+
+    # let mut app = App::new();
+    # app.add_plugins(RepliconPlugins);
+    app.replicate_bundle::<(Name, City)>() // Tuple of components is also a bundle!
+        .replicate_bundle::<PlayerBundle>();
+
+    #[derive(Component, Deserialize, Serialize)]
+    struct City;
+
+    #[derive(Bundle)]
+    struct PlayerBundle {
+        transform: Transform,
+        player: Player,
+    }
+
+    #[derive(Component, Deserialize, Serialize)]
+    struct Player;
+
+    impl BundleRules for PlayerBundle {
+        fn component_rules(world: &mut World, registry: &mut ReplicationRegistry) -> Vec<ComponentRule> {
+            // Customize serlialization to serialize only `translation`.
+            let (transform_id, transform_fns_id) = registry.register_rule_fns(
+                world,
+                RuleFns::new(serialize_translation, deserialize_translation),
+            );
+            let transform = ComponentRule::new(transform_id, transform_fns_id);
+
+            // Serialize `player` as usual.
+            let (player_id, player_fns_id) = registry.register_rule_fns(world, RuleFns::<Player>::default());
+            let player = ComponentRule::new(player_id, player_fns_id);
+
+            // We skip `replication` registration since it's a special component.
+            // It's automatically inserted on clients after replication and
+            // deserialization from scenes.
+
+            vec![transform, player]
+        }
+    }
+
+    # fn serialize_translation(_: &SerializeCtx, _: &Transform, _: &mut Vec<u8>) -> Result<()> { unimplemented!() }
+    # fn deserialize_translation(_: &mut WriteCtx, _: &mut Bytes) -> Result<Transform> { unimplemented!() }
+    ```
+    **/
+    fn replicate_bundle<B: BundleRules>(&mut self) -> &mut Self;
 }
 
 impl AppRuleExt for App {

--- a/src/shared/replication/rules/component.rs
+++ b/src/shared/replication/rules/component.rs
@@ -133,6 +133,7 @@ impl<C: IntoComponentRule> IntoComponentRules for C {
 macro_rules! impl_into_component_rules {
     ($(($n:tt, $R:ident)),*) => {
         impl<$($R: IntoComponentRule),*> IntoComponentRules for ($($R,)*) {
+            // A dummy variable to add 1 for each tuple element.
             const DEFAULT_PRIORITY: usize = 0 $(+ { let _ = $n; 1 })*;
 
             fn into_rules(

--- a/src/shared/replication/rules/component.rs
+++ b/src/shared/replication/rules/component.rs
@@ -59,7 +59,7 @@ pub enum SendRate {
 }
 
 impl SendRate {
-    /// Returns `true` if a mutation for should be replicated on this tick.
+    /// Returns `true` if a mutation for a component in a replication rule should be replicated on this tick.
     pub fn send_mutations(self, tick: RepliconTick) -> bool {
         match self {
             SendRate::EveryTick => true,

--- a/src/shared/replication/rules/component.rs
+++ b/src/shared/replication/rules/component.rs
@@ -69,7 +69,7 @@ impl SendRate {
     }
 }
 
-/// Parameters for that can be turned into a component replication rule.
+/// Parameters that can be turned into a component replication rule.
 ///
 /// Used for [`IntoComponentRules`] to accept either [`RuleFns`] or a tuple combining
 /// [`RuleFns`] with an associated [`SendRate`].

--- a/src/shared/replication/rules/component.rs
+++ b/src/shared/replication/rules/component.rs
@@ -1,0 +1,190 @@
+use bevy::{ecs::component::ComponentId, prelude::*};
+use serde::{Serialize, de::DeserializeOwned};
+
+use crate::{
+    prelude::*,
+    shared::replication::registry::{FnsId, ReplicationRegistry, command_fns::MutWrite},
+};
+
+/// Component for [`ReplicationRule`](super::ReplicationRule).
+#[derive(Clone, Copy, Debug)]
+pub struct ComponentRule {
+    /// ID of the replicated component.
+    pub id: ComponentId,
+    /// Associated serialization and deserialization functions.
+    pub fns_id: FnsId,
+    /// Send rate configuration.
+    pub send_rate: SendRate,
+}
+
+impl ComponentRule {
+    /// Creates a new instance with the default send rate.
+    pub fn new(id: ComponentId, fns_id: FnsId) -> Self {
+        Self {
+            id,
+            fns_id,
+            send_rate: Default::default(),
+        }
+    }
+}
+
+/// Describes how often component changes should be replicated.
+///
+/// Used inside [`ComponentRule`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SendRate {
+    /// Replicate any change every tick.
+    ///
+    /// If multiple changes occur in the same tick,
+    /// only the latest value will be replicated.
+    #[default]
+    EveryTick,
+
+    /// Replicates only the initial value and removal.
+    ///
+    /// Component mutations won't be sent.
+    Once,
+
+    /// Replicate mutations at a specified interval.
+    ///
+    /// If multiple mutations occur within the interval,
+    /// only the latest value at the time of sending will
+    /// be replicated.
+    ///
+    /// Does not affect initial values or removals.
+    ///
+    /// For example, with a period of 2, any mutation
+    /// will be replicated every second tick.
+    Periodic(u32),
+}
+
+impl SendRate {
+    /// Returns `true` if a mutation for should be replicated on this tick.
+    pub fn send_mutations(self, tick: RepliconTick) -> bool {
+        match self {
+            SendRate::EveryTick => true,
+            SendRate::Once => false,
+            SendRate::Periodic(period) => tick.get() % period == 0,
+        }
+    }
+}
+
+/// Parameters for that can be turned into a component replication rule.
+///
+/// Used for [`IntoComponentRules`] to accept either [`RuleFns`] or a tuple combining
+/// [`RuleFns`] with an associated [`SendRate`].
+///
+/// See [`AppRuleExt::replicate_with`] for more details.
+pub trait IntoComponentRule {
+    /// Turns into a component replication rule and registers its functions in [`ReplicationRegistry`].
+    fn into_rule(self, world: &mut World, registry: &mut ReplicationRegistry) -> ComponentRule;
+}
+
+impl<C: Component<Mutability: MutWrite<C>>> IntoComponentRule for RuleFns<C> {
+    fn into_rule(self, world: &mut World, registry: &mut ReplicationRegistry) -> ComponentRule {
+        let (id, fns_id) = registry.register_rule_fns(world, self);
+        ComponentRule::new(id, fns_id)
+    }
+}
+
+impl<C: Component<Mutability: MutWrite<C>>> IntoComponentRule for (RuleFns<C>, SendRate) {
+    fn into_rule(self, world: &mut World, registry: &mut ReplicationRegistry) -> ComponentRule {
+        let (rule_fns, send_rate) = self;
+        let (id, fns_id) = registry.register_rule_fns(world, rule_fns);
+        ComponentRule {
+            id,
+            fns_id,
+            send_rate,
+        }
+    }
+}
+
+/// Parameters that can be turned into a list of component replication rules.
+///
+/// Implemented for tuples of [`IntoComponentRule`].
+///
+/// See [`AppRuleExt::replicate_with`] for more details.
+pub trait IntoComponentRules {
+    /// Priority when registered with [`AppRuleExt::replicate_with`].
+    ///
+    /// Equals the number of components in a rule.
+    const DEFAULT_PRIORITY: usize;
+
+    /// Turns into a replication rule and registers its functions in [`ReplicationRegistry`].
+    fn into_rules(
+        self,
+        world: &mut World,
+        registry: &mut ReplicationRegistry,
+    ) -> Vec<ComponentRule>;
+}
+
+impl<C: IntoComponentRule> IntoComponentRules for C {
+    const DEFAULT_PRIORITY: usize = 1;
+
+    fn into_rules(
+        self,
+        world: &mut World,
+        registry: &mut ReplicationRegistry,
+    ) -> Vec<ComponentRule> {
+        vec![self.into_rule(world, registry)]
+    }
+}
+
+macro_rules! impl_into_component_rules {
+    ($(($n:tt, $R:ident)),*) => {
+        impl<$($R: IntoComponentRule),*> IntoComponentRules for ($($R,)*) {
+            const DEFAULT_PRIORITY: usize = 0 $(+ { let _ = $n; 1 })*;
+
+            fn into_rules(
+                self,
+                world: &mut World,
+                registry: &mut ReplicationRegistry,
+            ) -> Vec<ComponentRule> {
+                vec![
+                    $(
+                        self.$n.into_rule(world, registry),
+                    )*
+                ]
+            }
+        }
+    }
+}
+
+variadics_please::all_tuples_enumerated!(impl_into_component_rules, 1, 15, R);
+
+/// Component replication rules associated with a bundle and its priority.
+///
+/// See [`AppRuleExt::replicate_bundle`] for more details.
+pub trait BundleRules {
+    /// By default the priority equals the number of components.
+    ///
+    /// If this constant is set, its value will be used instead.
+    const CUSTOM_PRIORITY: Option<usize> = None;
+
+    /// Creates the associated component replication rules and registers their functions in [`ReplicationRegistry`].
+    fn component_rules(world: &mut World, registry: &mut ReplicationRegistry)
+    -> Vec<ComponentRule>;
+}
+
+macro_rules! impl_into_bundle_rules {
+    ($($C:ident),*) => {
+        impl<$($C: Component<Mutability: MutWrite<$C>> + Serialize + DeserializeOwned),*> BundleRules for ($($C,)*) {
+            fn component_rules(world: &mut World, registry: &mut ReplicationRegistry) -> Vec<ComponentRule> {
+                vec![
+                    $(
+                        {
+                            let (id, fns_id) = registry.register_rule_fns(world, RuleFns::<$C>::default());
+                            ComponentRule {
+                                id,
+                                fns_id,
+                                send_rate: Default::default(),
+                            }
+                        },
+                    )*
+                ]
+            }
+        }
+    }
+}
+
+variadics_please::all_tuples!(impl_into_bundle_rules, 1, 15, C);

--- a/src/shared/replication/rules/component.rs
+++ b/src/shared/replication/rules/component.rs
@@ -133,7 +133,7 @@ impl<C: IntoComponentRule> IntoComponentRules for C {
 macro_rules! impl_into_component_rules {
     ($(($n:tt, $R:ident)),*) => {
         impl<$($R: IntoComponentRule),*> IntoComponentRules for ($($R,)*) {
-            // A dummy variable to add 1 for each tuple element.
+            // Create a dummy variable to add 1 for each tuple element.
             const DEFAULT_PRIORITY: usize = 0 $(+ { let _ = $n; 1 })*;
 
             fn into_rules(

--- a/src/shared/replication/rules/component.rs
+++ b/src/shared/replication/rules/component.rs
@@ -133,7 +133,7 @@ impl<C: IntoComponentRule> IntoComponentRules for C {
 macro_rules! impl_into_component_rules {
     ($(($n:tt, $R:ident)),*) => {
         impl<$($R: IntoComponentRule),*> IntoComponentRules for ($($R,)*) {
-            // Create a dummy variable to add 1 for each tuple element.
+            // Uses dummy variable `n` to add 1 for each tuple element.
             const DEFAULT_PRIORITY: usize = 0 $(+ { let _ = $n; 1 })*;
 
             fn into_rules(


### PR DESCRIPTION
Requires #533.

We need to store filters inside replication rules, but they aren't created by our rule traits and are instead passed as a separate parameter. This commit slightly changes the traits to produce only `Vec<ComponentRule>` and moves component-related rules into a separate module. No other logical changes.

Split into 2 commits to simplify the review.