### PR TITLE
Omit `Component` word from component names in tests

### DIFF
--- a/src/server/removal_buffer.rs
+++ b/src/server/removal_buffer.rs
@@ -178,9 +178,7 @@ mod tests {
 
         app.update();
 
-        app.world_mut()
-            .spawn((Replicated, ComponentA))
-            .remove::<ComponentA>();
+        app.world_mut().spawn((Replicated, A)).remove::<A>();
 
         app.update();
 
@@ -196,15 +194,11 @@ mod tests {
             .init_resource::<ReplicationRegistry>()
             .init_resource::<RemovalBuffer>()
             .add_systems(PostUpdate, server::buffer_removals)
-            .replicate::<ComponentA>();
+            .replicate::<A>();
 
         app.update();
 
-        let entity = app
-            .world_mut()
-            .spawn((Replicated, ComponentA))
-            .remove::<ComponentA>()
-            .id();
+        let entity = app.world_mut().spawn((Replicated, A)).remove::<A>().id();
 
         app.update();
 
@@ -223,14 +217,14 @@ mod tests {
             .init_resource::<ReplicationRegistry>()
             .init_resource::<RemovalBuffer>()
             .add_systems(PostUpdate, server::buffer_removals)
-            .replicate_bundle::<(ComponentA, ComponentB)>();
+            .replicate_bundle::<(A, B)>();
 
         app.update();
 
         let entity = app
             .world_mut()
-            .spawn((Replicated, ComponentA, ComponentB))
-            .remove::<(ComponentA, ComponentB)>()
+            .spawn((Replicated, A, B))
+            .remove::<(A, B)>()
             .id();
 
         app.update();
@@ -250,15 +244,11 @@ mod tests {
             .init_resource::<ReplicationRegistry>()
             .init_resource::<RemovalBuffer>()
             .add_systems(PostUpdate, server::buffer_removals)
-            .replicate_bundle::<(ComponentA, ComponentB)>();
+            .replicate_bundle::<(A, B)>();
 
         app.update();
 
-        let entity = app
-            .world_mut()
-            .spawn((Replicated, ComponentA, ComponentB))
-            .remove::<ComponentA>()
-            .id();
+        let entity = app.world_mut().spawn((Replicated, A, B)).remove::<A>().id();
 
         app.update();
 
@@ -277,15 +267,15 @@ mod tests {
             .init_resource::<ReplicationRegistry>()
             .init_resource::<RemovalBuffer>()
             .add_systems(PostUpdate, server::buffer_removals)
-            .replicate::<ComponentA>()
-            .replicate_bundle::<(ComponentA, ComponentB)>();
+            .replicate::<A>()
+            .replicate_bundle::<(A, B)>();
 
         app.update();
 
         let entity = app
             .world_mut()
-            .spawn((Replicated, ComponentA, ComponentB))
-            .remove::<(ComponentA, ComponentB)>()
+            .spawn((Replicated, A, B))
+            .remove::<(A, B)>()
             .id();
 
         app.update();
@@ -305,16 +295,12 @@ mod tests {
             .init_resource::<ReplicationRegistry>()
             .init_resource::<RemovalBuffer>()
             .add_systems(PostUpdate, server::buffer_removals)
-            .replicate::<ComponentA>()
-            .replicate_bundle::<(ComponentA, ComponentB)>();
+            .replicate::<A>()
+            .replicate_bundle::<(A, B)>();
 
         app.update();
 
-        let entity = app
-            .world_mut()
-            .spawn((Replicated, ComponentA, ComponentB))
-            .remove::<ComponentA>()
-            .id();
+        let entity = app.world_mut().spawn((Replicated, A, B)).remove::<A>().id();
 
         app.update();
 
@@ -333,11 +319,11 @@ mod tests {
             .init_resource::<ReplicationRegistry>()
             .init_resource::<RemovalBuffer>()
             .add_systems(PostUpdate, server::buffer_removals)
-            .replicate::<ComponentA>();
+            .replicate::<A>();
 
         app.update();
 
-        app.world_mut().spawn((ComponentA, Replicated)).despawn();
+        app.world_mut().spawn((Replicated, A)).despawn();
 
         app.update();
 
@@ -349,8 +335,8 @@ mod tests {
     }
 
     #[derive(Serialize, Deserialize, Component)]
-    struct ComponentA;
+    struct A;
 
     #[derive(Serialize, Deserialize, Component)]
-    struct ComponentB;
+    struct B;
 }

--- a/src/server/server_world.rs
+++ b/src/server/server_world.rs
@@ -316,14 +316,14 @@ mod tests {
         app.init_resource::<ProtocolHasher>()
             .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
-            .replicate::<ComponentA>()
+            .replicate::<A>()
             .add_systems(Update, |world: ServerWorld| {
                 assert_eq!(world.state.archetypes.len(), 1);
                 let archetype = world.state.archetypes.first().unwrap();
                 assert!(archetype.components.is_empty());
             });
 
-        app.world_mut().spawn((Replicated, ComponentB));
+        app.world_mut().spawn((Replicated, B));
         app.update();
     }
 
@@ -333,14 +333,14 @@ mod tests {
         app.init_resource::<ProtocolHasher>()
             .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
-            .replicate::<ComponentA>()
+            .replicate::<A>()
             .add_systems(Update, |world: ServerWorld| {
                 assert_eq!(world.state.archetypes.len(), 1);
                 let archetype = world.state.archetypes.first().unwrap();
                 assert_eq!(archetype.components.len(), 1);
             });
 
-        app.world_mut().spawn((Replicated, ComponentA));
+        app.world_mut().spawn((Replicated, A));
         app.update();
     }
 
@@ -350,14 +350,14 @@ mod tests {
         app.init_resource::<ProtocolHasher>()
             .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
-            .replicate_bundle::<(ComponentA, ComponentB)>()
+            .replicate_bundle::<(A, B)>()
             .add_systems(Update, |world: ServerWorld| {
                 assert_eq!(world.state.archetypes.len(), 1);
                 let archetype = world.state.archetypes.first().unwrap();
                 assert_eq!(archetype.components.len(), 2);
             });
 
-        app.world_mut().spawn((Replicated, ComponentA, ComponentB));
+        app.world_mut().spawn((Replicated, A, B));
         app.update();
     }
 
@@ -367,14 +367,14 @@ mod tests {
         app.init_resource::<ProtocolHasher>()
             .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
-            .replicate_bundle::<(ComponentA, ComponentB)>()
+            .replicate_bundle::<(A, B)>()
             .add_systems(Update, |world: ServerWorld| {
                 assert_eq!(world.state.archetypes.len(), 1);
                 let archetype = world.state.archetypes.first().unwrap();
                 assert!(archetype.components.is_empty());
             });
 
-        app.world_mut().spawn((Replicated, ComponentA));
+        app.world_mut().spawn((Replicated, A));
         app.update();
     }
 
@@ -384,15 +384,15 @@ mod tests {
         app.init_resource::<ProtocolHasher>()
             .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
-            .replicate::<ComponentA>()
-            .replicate_bundle::<(ComponentA, ComponentB)>()
+            .replicate::<A>()
+            .replicate_bundle::<(A, B)>()
             .add_systems(Update, |world: ServerWorld| {
                 assert_eq!(world.state.archetypes.len(), 1);
                 let archetype = world.state.archetypes.first().unwrap();
                 assert_eq!(archetype.components.len(), 2);
             });
 
-        app.world_mut().spawn((Replicated, ComponentA, ComponentB));
+        app.world_mut().spawn((Replicated, A, B));
         app.update();
     }
 
@@ -402,16 +402,16 @@ mod tests {
         app.init_resource::<ProtocolHasher>()
             .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
-            .replicate::<ComponentA>()
-            .replicate::<ComponentB>()
-            .replicate_bundle::<(ComponentA, ComponentB)>()
+            .replicate::<A>()
+            .replicate::<B>()
+            .replicate_bundle::<(A, B)>()
             .add_systems(Update, |world: ServerWorld| {
                 assert_eq!(world.state.archetypes.len(), 1);
                 let archetype = world.state.archetypes.first().unwrap();
                 assert_eq!(archetype.components.len(), 2);
             });
 
-        app.world_mut().spawn((Replicated, ComponentA, ComponentB));
+        app.world_mut().spawn((Replicated, A, B));
         app.update();
     }
 
@@ -421,25 +421,24 @@ mod tests {
         app.init_resource::<ProtocolHasher>()
             .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
-            .replicate_bundle::<(ComponentA, ComponentC)>()
-            .replicate_bundle::<(ComponentA, ComponentB)>()
+            .replicate_bundle::<(A, C)>()
+            .replicate_bundle::<(A, B)>()
             .add_systems(Update, |world: ServerWorld| {
                 assert_eq!(world.state.archetypes.len(), 1);
                 let archetype = world.state.archetypes.first().unwrap();
                 assert_eq!(archetype.components.len(), 3);
             });
 
-        app.world_mut()
-            .spawn((Replicated, ComponentA, ComponentB, ComponentC));
+        app.world_mut().spawn((Replicated, A, B, C));
         app.update();
     }
 
     #[derive(Serialize, Deserialize, Component)]
-    struct ComponentA;
+    struct A;
 
     #[derive(Serialize, Deserialize, Component)]
-    struct ComponentB;
+    struct B;
 
     #[derive(Serialize, Deserialize, Component)]
-    struct ComponentC;
+    struct C;
 }

--- a/src/shared/replication/registry.rs
+++ b/src/shared/replication/registry.rs
@@ -189,7 +189,7 @@ mod tests {
     fn rule_fns() {
         let mut world = World::new();
         let mut registry = ReplicationRegistry::default();
-        registry.register_rule_fns(&mut world, RuleFns::<ComponentA>::default());
+        registry.register_rule_fns(&mut world, RuleFns::<A>::default());
         assert_eq!(registry.rules.len(), 1);
         assert_eq!(registry.components.len(), 1);
     }
@@ -198,8 +198,8 @@ mod tests {
     fn duplicate_rule_fns() {
         let mut world = World::new();
         let mut registry = ReplicationRegistry::default();
-        registry.register_rule_fns(&mut world, RuleFns::<ComponentA>::default());
-        registry.register_rule_fns(&mut world, RuleFns::<ComponentA>::default());
+        registry.register_rule_fns(&mut world, RuleFns::<A>::default());
+        registry.register_rule_fns(&mut world, RuleFns::<A>::default());
 
         assert_eq!(registry.rules.len(), 2);
         assert_eq!(
@@ -213,16 +213,16 @@ mod tests {
     fn different_rule_fns() {
         let mut world = World::new();
         let mut registry = ReplicationRegistry::default();
-        registry.register_rule_fns(&mut world, RuleFns::<ComponentA>::default());
-        registry.register_rule_fns(&mut world, RuleFns::<ComponentB>::default());
+        registry.register_rule_fns(&mut world, RuleFns::<A>::default());
+        registry.register_rule_fns(&mut world, RuleFns::<B>::default());
 
         assert_eq!(registry.rules.len(), 2);
         assert_eq!(registry.components.len(), 2);
     }
 
     #[derive(Component, Serialize, Deserialize)]
-    struct ComponentA;
+    struct A;
 
     #[derive(Component, Deserialize, Serialize)]
-    struct ComponentB;
+    struct B;
 }

--- a/src/shared/replication/rules.rs
+++ b/src/shared/replication/rules.rs
@@ -749,31 +749,22 @@ mod tests {
         app.init_resource::<ProtocolHasher>()
             .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
-            .replicate::<ComponentA>()
+            .replicate::<A>()
+            .replicate_with((RuleFns::<A>::default(), RuleFns::<B>::default()))
+            .replicate_once::<B>()
             .replicate_with((
-                RuleFns::<ComponentA>::default(),
-                RuleFns::<ComponentB>::default(),
+                (RuleFns::<B>::default(), SendRate::Once),
+                (RuleFns::<C>::default(), SendRate::Periodic(2)),
             ))
-            .replicate_once::<ComponentB>()
-            .replicate_with((
-                (RuleFns::<ComponentB>::default(), SendRate::Once),
-                (RuleFns::<ComponentC>::default(), SendRate::Periodic(2)),
-            ))
-            .replicate_periodic::<ComponentC>(1)
-            .replicate_with_priority(
-                4,
-                (
-                    RuleFns::<ComponentC>::default(),
-                    RuleFns::<ComponentD>::default(),
-                ),
-            )
-            .replicate_with((RuleFns::<ComponentD>::default(), SendRate::Once))
-            .replicate_bundle::<(ComponentA, ComponentB)>();
+            .replicate_periodic::<C>(1)
+            .replicate_with_priority(4, (RuleFns::<C>::default(), RuleFns::<D>::default()))
+            .replicate_with((RuleFns::<D>::default(), SendRate::Once))
+            .replicate_bundle::<(A, B)>();
 
-        let a = app.world().component_id::<ComponentA>().unwrap();
-        let b = app.world().component_id::<ComponentB>().unwrap();
-        let c = app.world().component_id::<ComponentC>().unwrap();
-        let d = app.world().component_id::<ComponentD>().unwrap();
+        let a = app.world().component_id::<A>().unwrap();
+        let b = app.world().component_id::<B>().unwrap();
+        let c = app.world().component_id::<C>().unwrap();
+        let d = app.world().component_id::<D>().unwrap();
 
         let rules = &**app.world().resource::<ReplicationRules>();
 
@@ -819,14 +810,14 @@ mod tests {
     }
 
     #[derive(Serialize, Deserialize, Component)]
-    struct ComponentA;
+    struct A;
 
     #[derive(Serialize, Deserialize, Component)]
-    struct ComponentB;
+    struct B;
 
     #[derive(Serialize, Deserialize, Component)]
-    struct ComponentC;
+    struct C;
 
     #[derive(Serialize, Deserialize, Component)]
-    struct ComponentD;
+    struct D;
 }

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -28,7 +28,7 @@ fn table_storage() {
                 ..Default::default()
             }),
         ))
-        .replicate::<TableComponent>()
+        .replicate::<Table>()
         .finish();
     }
 
@@ -44,13 +44,13 @@ fn table_storage() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .insert(TableComponent);
+        .insert(Table);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let mut components = client_app.world_mut().query::<&TableComponent>();
+    let mut components = client_app.world_mut().query::<&Table>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
@@ -66,7 +66,7 @@ fn sparse_set_storage() {
                 ..Default::default()
             }),
         ))
-        .replicate::<SparseSetComponent>()
+        .replicate::<SparseSet>()
         .finish();
     }
 
@@ -82,13 +82,13 @@ fn sparse_set_storage() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .insert(SparseSetComponent);
+        .insert(SparseSet);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let mut components = client_app.world_mut().query::<&SparseSetComponent>();
+    let mut components = client_app.world_mut().query::<&SparseSet>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
@@ -104,7 +104,7 @@ fn immutable() {
                 ..Default::default()
             }),
         ))
-        .replicate::<ImmutableComponent>()
+        .replicate::<Immutable>()
         .finish();
     }
 
@@ -120,20 +120,20 @@ fn immutable() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .insert(ImmutableComponent(false));
+        .insert(Immutable(false));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let mut components = client_app.world_mut().query::<&ImmutableComponent>();
+    let mut components = client_app.world_mut().query::<&Immutable>();
     let component = components.single(client_app.world()).unwrap();
     assert!(!component.0);
 
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .insert(ImmutableComponent(true));
+        .insert(Immutable(true));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -251,8 +251,8 @@ fn multiple_components() {
                 ..Default::default()
             }),
         ))
-        .replicate::<ComponentA>()
-        .replicate::<ComponentB>()
+        .replicate::<A>()
+        .replicate::<B>()
         .finish();
     }
 
@@ -270,13 +270,13 @@ fn multiple_components() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .insert((ComponentA, ComponentB));
+        .insert((A, B));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let mut components = client_app.world_mut().query::<(&ComponentA, &ComponentB)>();
+    let mut components = client_app.world_mut().query::<(&A, &B)>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
     assert_eq!(
         client_app.world().archetypes().len() - before_archetypes,
@@ -297,8 +297,8 @@ fn command_fns() {
                 ..Default::default()
             }),
         ))
-        .replicate::<OriginalComponent>()
-        .set_command_fns(replace, command_fns::default_remove::<ReplacedComponent>)
+        .replicate::<Original>()
+        .set_command_fns(replace, command_fns::default_remove::<Replaced>)
         .finish();
     }
 
@@ -314,7 +314,7 @@ fn command_fns() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .insert(OriginalComponent);
+        .insert(Original);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -322,7 +322,7 @@ fn command_fns() {
 
     let mut components = client_app
         .world_mut()
-        .query_filtered::<&ReplacedComponent, Without<OriginalComponent>>();
+        .query_filtered::<&Replaced, Without<Original>>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
@@ -339,11 +339,8 @@ fn marker() {
             }),
         ))
         .register_marker::<ReplaceMarker>()
-        .replicate::<OriginalComponent>()
-        .set_marker_fns::<ReplaceMarker, _>(
-            replace,
-            command_fns::default_remove::<ReplacedComponent>,
-        )
+        .replicate::<Original>()
+        .set_marker_fns::<ReplaceMarker, _>(replace, command_fns::default_remove::<Replaced>)
         .finish();
     }
 
@@ -368,15 +365,15 @@ fn marker() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .insert(OriginalComponent);
+        .insert(Original);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
     let client_entity = client_app.world().entity(client_entity);
-    assert!(!client_entity.contains::<OriginalComponent>());
-    assert!(client_entity.contains::<ReplacedComponent>());
+    assert!(!client_entity.contains::<Original>());
+    assert!(client_entity.contains::<Replaced>());
 }
 
 #[test]
@@ -391,7 +388,7 @@ fn group() {
                 ..Default::default()
             }),
         ))
-        .replicate_bundle::<(ComponentA, ComponentB)>()
+        .replicate_bundle::<(A, B)>()
         .finish();
     }
 
@@ -407,13 +404,13 @@ fn group() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .insert((ComponentA, ComponentB));
+        .insert((A, B));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let mut groups = client_app.world_mut().query::<(&ComponentA, &ComponentB)>();
+    let mut groups = client_app.world_mut().query::<(&A, &B)>();
     assert_eq!(groups.iter(client_app.world()).count(), 1);
 }
 
@@ -441,16 +438,13 @@ fn not_replicated() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    server_app
-        .world_mut()
-        .entity_mut(server_entity)
-        .insert(TestComponent);
+    server_app.world_mut().entity_mut(server_entity).insert(A);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let mut components = client_app.world_mut().query::<&TestComponent>();
+    let mut components = client_app.world_mut().query::<&A>();
     assert_eq!(components.iter(client_app.world()).count(), 0);
 }
 
@@ -466,16 +460,13 @@ fn after_removal() {
                 ..Default::default()
             }),
         ))
-        .replicate::<TestComponent>()
+        .replicate::<A>()
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app
-        .world_mut()
-        .spawn((Replicated, TestComponent))
-        .id();
+    let server_entity = server_app.world_mut().spawn((Replicated, A)).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -486,17 +477,17 @@ fn after_removal() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .remove::<TestComponent>()
-        .insert(TestComponent);
+        .remove::<A>()
+        .insert(A);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let mut components = client_app.world_mut().query::<&TestComponent>();
+    let mut components = client_app.world_mut().query::<&A>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
 
-    let mut system_state: SystemState<RemovedComponents<TestComponent>> =
+    let mut system_state: SystemState<RemovedComponents<A>> =
         SystemState::new(client_app.world_mut());
     let removals = system_state.get(client_app.world());
     assert_eq!(
@@ -522,20 +513,20 @@ fn before_started_replication() {
                     ..Default::default()
                 }),
         ))
-        .replicate::<TestComponent>()
+        .replicate::<A>()
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
-    server_app.world_mut().spawn((Replicated, TestComponent));
+    server_app.world_mut().spawn((Replicated, A));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    let mut components = client_app.world_mut().query::<&TestComponent>();
+    let mut components = client_app.world_mut().query::<&A>();
     assert_eq!(
         components.iter(client_app.world()).count(),
         0,
@@ -572,7 +563,7 @@ fn after_started_replication() {
                     ..Default::default()
                 }),
         ))
-        .replicate::<TestComponent>()
+        .replicate::<A>()
         .finish();
     }
 
@@ -589,14 +580,14 @@ fn after_started_replication() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    server_app.world_mut().spawn((Replicated, TestComponent));
+    server_app.world_mut().spawn((Replicated, A));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    let mut components = client_app.world_mut().query::<&TestComponent>();
+    let mut components = client_app.world_mut().query::<&A>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
@@ -612,7 +603,7 @@ fn confirm_history() {
                 ..Default::default()
             }),
         ))
-        .replicate::<TestComponent>()
+        .replicate::<A>()
         .finish();
     }
 
@@ -625,10 +616,7 @@ fn confirm_history() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    server_app
-        .world_mut()
-        .entity_mut(server_entity)
-        .insert(TestComponent);
+    server_app.world_mut().entity_mut(server_entity).insert(A);
 
     // Clear previous events.
     client_app
@@ -663,46 +651,43 @@ fn confirm_history() {
 
 #[derive(Component, Deserialize, Serialize)]
 #[component(storage = "Table")]
-struct TableComponent;
+struct Table;
 
 #[derive(Component, Deserialize, Serialize)]
 #[component(storage = "SparseSet")]
-struct SparseSetComponent;
-
-#[derive(Component, Deserialize, Serialize)]
-struct TestComponent;
+struct SparseSet;
 
 #[derive(Component, Deserialize, Serialize)]
 struct MappedComponent(#[entities] Entity);
 
 #[derive(Component, Deserialize, Serialize)]
 #[component(immutable)]
-struct ImmutableComponent(bool);
+struct Immutable(bool);
 
 #[derive(Component, Deserialize, Serialize)]
-struct ComponentA;
+struct A;
 
 #[derive(Component, Deserialize, Serialize)]
-struct ComponentB;
+struct B;
 
 #[derive(Component)]
 struct ReplaceMarker;
 
 #[derive(Component, Deserialize, Serialize)]
-struct OriginalComponent;
+struct Original;
 
 #[derive(Component, Deserialize, Serialize)]
-struct ReplacedComponent;
+struct Replaced;
 
 /// Deserializes [`OriginalComponent`], but ignores it and inserts [`ReplacedComponent`].
 fn replace(
     ctx: &mut WriteCtx,
-    rule_fns: &RuleFns<OriginalComponent>,
+    rule_fns: &RuleFns<Original>,
     entity: &mut DeferredEntity,
     message: &mut Bytes,
 ) -> Result<()> {
     rule_fns.deserialize(ctx, message)?;
-    entity.insert(ReplacedComponent);
+    entity.insert(Replaced);
 
     Ok(())
 }

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -25,29 +25,26 @@ fn single() {
                 ..Default::default()
             }),
         ))
-        .replicate::<TestComponent>()
+        .replicate::<A>()
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app
-        .world_mut()
-        .spawn((Replicated, TestComponent))
-        .id();
+    let server_entity = server_app.world_mut().spawn((Replicated, A)).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    let mut components = client_app.world_mut().query::<&TestComponent>();
+    let mut components = client_app.world_mut().query::<&A>();
     assert_eq!(components.iter(client_app.world()).len(), 1);
 
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .remove::<TestComponent>();
+        .remove::<A>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -68,24 +65,21 @@ fn multiple() {
                 ..Default::default()
             }),
         ))
-        .replicate::<ComponentA>()
-        .replicate::<ComponentB>()
+        .replicate::<A>()
+        .replicate::<B>()
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app
-        .world_mut()
-        .spawn((Replicated, ComponentA, ComponentB))
-        .id();
+    let server_entity = server_app.world_mut().spawn((Replicated, A, B)).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    let mut components = client_app.world_mut().query::<(&ComponentA, &ComponentB)>();
+    let mut components = client_app.world_mut().query::<(&A, &B)>();
     assert_eq!(components.iter(client_app.world()).len(), 1);
 
     let before_archetypes = client_app.world().archetypes().len();
@@ -93,7 +87,7 @@ fn multiple() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .remove::<(ComponentA, ComponentB)>();
+        .remove::<(A, B)>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -119,30 +113,27 @@ fn command_fns() {
                 ..Default::default()
             }),
         ))
-        .replicate::<OriginalComponent>()
-        .set_command_fns(replace, command_fns::default_remove::<ReplacedComponent>)
+        .replicate::<Original>()
+        .set_command_fns(replace, command_fns::default_remove::<Replaced>)
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app
-        .world_mut()
-        .spawn((Replicated, OriginalComponent))
-        .id();
+    let server_entity = server_app.world_mut().spawn((Replicated, Original)).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    let mut components = client_app.world_mut().query::<&ReplacedComponent>();
+    let mut components = client_app.world_mut().query::<&Replaced>();
     assert_eq!(components.iter(client_app.world()).len(), 1);
 
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .remove::<OriginalComponent>();
+        .remove::<Original>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -164,20 +155,14 @@ fn marker() {
             }),
         ))
         .register_marker::<ReplaceMarker>()
-        .replicate::<OriginalComponent>()
-        .set_marker_fns::<ReplaceMarker, _>(
-            replace,
-            command_fns::default_remove::<ReplacedComponent>,
-        )
+        .replicate::<Original>()
+        .set_marker_fns::<ReplaceMarker, _>(replace, command_fns::default_remove::<Replaced>)
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app
-        .world_mut()
-        .spawn((Replicated, OriginalComponent))
-        .id();
+    let server_entity = server_app.world_mut().spawn((Replicated, Original)).id();
 
     let client_entity = client_app.world_mut().spawn(ReplaceMarker).id();
 
@@ -196,14 +181,14 @@ fn marker() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .remove::<OriginalComponent>();
+        .remove::<Original>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
     let client_entity = client_app.world().entity(client_entity);
-    assert!(!client_entity.contains::<ReplacedComponent>());
+    assert!(!client_entity.contains::<Replaced>());
 }
 
 #[test]
@@ -218,16 +203,13 @@ fn group() {
                 ..Default::default()
             }),
         ))
-        .replicate_bundle::<(ComponentA, ComponentB)>()
+        .replicate_bundle::<(A, B)>()
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app
-        .world_mut()
-        .spawn((Replicated, (ComponentA, ComponentB)))
-        .id();
+    let server_entity = server_app.world_mut().spawn((Replicated, (A, B))).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -236,22 +218,22 @@ fn group() {
 
     let client_entity = client_app
         .world_mut()
-        .query_filtered::<Entity, (With<ComponentA>, With<ComponentB>)>()
+        .query_filtered::<Entity, (With<A>, With<B>)>()
         .single(client_app.world())
         .unwrap();
 
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .remove::<(ComponentA, ComponentB)>();
+        .remove::<(A, B)>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
     let client_entity = client_app.world().entity(client_entity);
-    assert!(!client_entity.contains::<ComponentA>());
-    assert!(!client_entity.contains::<ComponentB>());
+    assert!(!client_entity.contains::<A>());
+    assert!(!client_entity.contains::<B>());
 }
 
 #[test]
@@ -273,7 +255,7 @@ fn not_replicated() {
 
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, NotReplicatedComponent))
+        .spawn((Replicated, NotReplicated))
         .id();
 
     server_app.update();
@@ -283,26 +265,26 @@ fn not_replicated() {
 
     let client_entity = client_app
         .world_mut()
-        .query_filtered::<Entity, (With<Replicated>, Without<NotReplicatedComponent>)>()
+        .query_filtered::<Entity, (With<Replicated>, Without<NotReplicated>)>()
         .single(client_app.world())
         .unwrap();
 
     client_app
         .world_mut()
         .entity_mut(client_entity)
-        .insert(NotReplicatedComponent);
+        .insert(NotReplicated);
 
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .remove::<NotReplicatedComponent>();
+        .remove::<NotReplicated>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
     let client_entity = client_app.world().entity(client_entity);
-    assert!(client_entity.contains::<NotReplicatedComponent>());
+    assert!(client_entity.contains::<NotReplicated>());
 }
 
 #[test]
@@ -317,31 +299,28 @@ fn after_insertion() {
                 ..Default::default()
             }),
         ))
-        .replicate::<TestComponent>()
+        .replicate::<A>()
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app
-        .world_mut()
-        .spawn((Replicated, TestComponent))
-        .id();
+    let server_entity = server_app.world_mut().spawn((Replicated, A)).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    let mut components = client_app.world_mut().query::<&TestComponent>();
+    let mut components = client_app.world_mut().query::<&A>();
     assert_eq!(components.iter(client_app.world()).len(), 1);
 
     // Insert and remove at the same time.
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .insert(TestComponent)
-        .remove::<TestComponent>();
+        .insert(A)
+        .remove::<A>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -362,16 +341,13 @@ fn with_spawn() {
                 ..Default::default()
             }),
         ))
-        .replicate::<TestComponent>()
+        .replicate::<A>()
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
-    server_app
-        .world_mut()
-        .spawn((Replicated, TestComponent))
-        .remove::<TestComponent>();
+    server_app.world_mut().spawn((Replicated, A)).remove::<A>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -379,7 +355,7 @@ fn with_spawn() {
 
     let mut components = client_app
         .world_mut()
-        .query_filtered::<&Replicated, Without<TestComponent>>();
+        .query_filtered::<&Replicated, Without<A>>();
     assert_eq!(components.iter(client_app.world()).len(), 1);
 }
 
@@ -395,16 +371,13 @@ fn with_despawn() {
                 ..Default::default()
             }),
         ))
-        .replicate::<TestComponent>()
+        .replicate::<A>()
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app
-        .world_mut()
-        .spawn((Replicated, TestComponent))
-        .id();
+    let server_entity = server_app.world_mut().spawn((Replicated, A)).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -418,7 +391,7 @@ fn with_despawn() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .remove::<TestComponent>()
+        .remove::<A>()
         .remove::<Replicated>();
 
     server_app.update();
@@ -440,16 +413,13 @@ fn confirm_history() {
                 ..Default::default()
             }),
         ))
-        .replicate::<TestComponent>()
+        .replicate::<A>()
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app
-        .world_mut()
-        .spawn((Replicated, TestComponent))
-        .id();
+    let server_entity = server_app.world_mut().spawn((Replicated, A)).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -458,14 +428,14 @@ fn confirm_history() {
 
     let client_entity = client_app
         .world_mut()
-        .query_filtered::<Entity, With<TestComponent>>()
+        .query_filtered::<Entity, With<A>>()
         .single(client_app.world())
         .unwrap();
 
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .remove::<TestComponent>();
+        .remove::<A>();
 
     // Clear previous events.
     client_app
@@ -510,16 +480,13 @@ fn hidden() {
                 ..Default::default()
             }),
         ))
-        .replicate::<TestComponent>()
+        .replicate::<A>()
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app
-        .world_mut()
-        .spawn((Replicated, TestComponent))
-        .id();
+    let server_entity = server_app.world_mut().spawn((Replicated, A)).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -529,7 +496,7 @@ fn hidden() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .remove::<TestComponent>();
+        .remove::<A>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -544,35 +511,32 @@ fn hidden() {
 }
 
 #[derive(Component, Deserialize, Serialize)]
-struct TestComponent;
+struct A;
 
 #[derive(Component, Deserialize, Serialize)]
-struct ComponentA;
+struct B;
 
 #[derive(Component, Deserialize, Serialize)]
-struct ComponentB;
-
-#[derive(Component, Deserialize, Serialize)]
-struct NotReplicatedComponent;
+struct NotReplicated;
 
 #[derive(Component)]
 struct ReplaceMarker;
 
 #[derive(Component, Deserialize, Serialize)]
-struct OriginalComponent;
+struct Original;
 
 #[derive(Component, Deserialize, Serialize)]
-struct ReplacedComponent;
+struct Replaced;
 
 /// Deserializes [`OriginalComponent`], but ignores it and inserts [`ReplacedComponent`].
 fn replace(
     ctx: &mut WriteCtx,
-    rule_fns: &RuleFns<OriginalComponent>,
+    rule_fns: &RuleFns<Original>,
     entity: &mut DeferredEntity,
     message: &mut Bytes,
 ) -> Result<()> {
     rule_fns.deserialize(ctx, message)?;
-    entity.insert(ReplacedComponent);
+    entity.insert(Replaced);
 
     Ok(())
 }

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -62,21 +62,19 @@ fn with_component() {
                 ..Default::default()
             }),
         ))
-        .replicate::<TestComponent>()
+        .replicate::<A>()
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
-    server_app.world_mut().spawn((Replicated, TestComponent));
+    server_app.world_mut().spawn((Replicated, A));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let mut components = client_app
-        .world_mut()
-        .query::<(&Replicated, &TestComponent)>();
+    let mut components = client_app.world_mut().query::<(&Replicated, &A)>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
@@ -92,8 +90,8 @@ fn with_multiple_components() {
                 ..Default::default()
             }),
         ))
-        .replicate::<ComponentA>()
-        .replicate::<ComponentB>()
+        .replicate::<A>()
+        .replicate::<B>()
         .finish();
     }
 
@@ -101,17 +99,13 @@ fn with_multiple_components() {
 
     let before_archetypes = client_app.world().archetypes().len();
 
-    server_app
-        .world_mut()
-        .spawn((Replicated, ComponentA, ComponentB));
+    server_app.world_mut().spawn((Replicated, A, B));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let mut components = client_app
-        .world_mut()
-        .query::<(&Replicated, &ComponentA, &ComponentB)>();
+    let mut components = client_app.world_mut().query::<(&Replicated, &A, &B)>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
     assert_eq!(
         client_app.world().archetypes().len() - before_archetypes,
@@ -132,14 +126,14 @@ fn with_old_component() {
                 ..Default::default()
             }),
         ))
-        .replicate::<TestComponent>()
+        .replicate::<A>()
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
     // Spawn an entity with replicated component, but without a marker.
-    let server_entity = server_app.world_mut().spawn(TestComponent).id();
+    let server_entity = server_app.world_mut().spawn(A).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -159,9 +153,7 @@ fn with_old_component() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let mut components = client_app
-        .world_mut()
-        .query::<(&Replicated, &TestComponent)>();
+    let mut components = client_app.world_mut().query::<(&Replicated, &A)>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
@@ -177,21 +169,19 @@ fn before_connection() {
                 ..Default::default()
             }),
         ))
-        .replicate::<TestComponent>()
+        .replicate::<A>()
         .finish();
     }
 
     // Spawn an entity before client connected.
-    server_app.world_mut().spawn((Replicated, TestComponent));
+    server_app.world_mut().spawn((Replicated, A));
 
     server_app.connect_client(&mut client_app);
 
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let mut components = client_app
-        .world_mut()
-        .query::<(&Replicated, &TestComponent)>();
+    let mut components = client_app.world_mut().query::<(&Replicated, &A)>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
@@ -207,17 +197,14 @@ fn pre_spawn() {
                 ..Default::default()
             }),
         ))
-        .replicate::<TestComponent>()
+        .replicate::<A>()
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
     let client_entity = client_app.world_mut().spawn_empty().id();
-    let server_entity = server_app
-        .world_mut()
-        .spawn((Replicated, TestComponent))
-        .id();
+    let server_entity = server_app.world_mut().spawn((Replicated, A)).id();
 
     let test_client_entity = **client_app.world().resource::<TestClientEntity>();
     let mut entity_map = server_app
@@ -252,7 +239,7 @@ fn pre_spawn() {
         "server should confirm replication of client entity"
     );
     assert!(
-        client_entity.contains::<TestComponent>(),
+        client_entity.contains::<A>(),
         "component from server should be replicated"
     );
 
@@ -276,7 +263,7 @@ fn after_despawn() {
                 ..Default::default()
             }),
         ))
-        .replicate::<TestComponent>()
+        .replicate::<A>()
         .finish();
     }
 
@@ -285,7 +272,7 @@ fn after_despawn() {
     // Remove and insert `Replicated` to trigger despawn and spawn for client at the same time.
     server_app
         .world_mut()
-        .spawn((Replicated, TestComponent))
+        .spawn((Replicated, A))
         .remove::<Replicated>()
         .insert(Replicated);
 
@@ -293,17 +280,12 @@ fn after_despawn() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let mut components = client_app
-        .world_mut()
-        .query::<(&Replicated, &TestComponent)>();
+    let mut components = client_app.world_mut().query::<(&Replicated, &A)>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
 #[derive(Component, Deserialize, Serialize)]
-struct TestComponent;
+struct A;
 
 #[derive(Component, Deserialize, Serialize)]
-struct ComponentA;
-
-#[derive(Component, Deserialize, Serialize)]
-struct ComponentB;
+struct B;


### PR DESCRIPTION
It's just much shorter. It's obvious they are components from the context.