### PR TITLE
Remove `VisibilityPolicy::All`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Removed
 
+- `VisibilityPolicy::All`. Use `VisibilityPolicy::Blacklist` instead, which is the default now. There are not performance difference when the list is empty.
 - `entity_serde::serialize_entity` and `entity_serde::deserialize_entity`. Use `postcard_utils::entity_to_extend_mut` and `postcard_utils::entity_from_buf` respectively; just swap the argument order.
 - `SERVER`. Use `ClientId::Server` instead.
 

--- a/src/server/client_visibility.rs
+++ b/src/server/client_visibility.rs
@@ -6,9 +6,8 @@ use bevy::{
 
 /// Entity visibility settings for a client.
 ///
-/// Dynamically marked as required for [`AuthorizedClient`](super::AuthorizedClient)
-/// if [`ServerPlugin::visibility_policy`](super::ServerPlugin::visibility_policy)
-/// is not set to [`VisibilityPolicy::All`](super::VisibilityPolicy::All).
+/// Dynamically marked as required for [`AuthorizedClient`](super::AuthorizedClient).
+/// based on [`ServerPlugin::visibility_policy`](super::ServerPlugin::visibility_policy).
 ///
 /// # Examples
 ///


### PR DESCRIPTION
Use `VisibilityPolicy::Blacklist` instead, which is the default now. There are not performance difference when the list is empty because hashmaps early-return in this case.

I also benchmarked it just in case to confirm this.