### PR TITLE
Minor `ack_mutate_message` refactor

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -262,12 +262,11 @@ fn receive_acks(
                             "messages from client `{client}` should have been removed on disconnect"
                         )
                     });
-                    ticks.ack_mutate_message(
-                        client,
-                        &mut entity_buffer,
-                        change_tick.this_run(),
-                        mutate_index,
-                    );
+                    if let Some(entities) =
+                        ticks.ack_mutate_message(client, change_tick.this_run(), mutate_index)
+                    {
+                        entity_buffer.push(entities);
+                    }
                 }
                 Err(e) => {
                     debug!("unable to deserialize mutate index from client `{client}`: {e}")

--- a/src/shared/replication/client_ticks.rs
+++ b/src/shared/replication/client_ticks.rs
@@ -93,13 +93,12 @@ impl ClientTicks {
     pub(crate) fn ack_mutate_message(
         &mut self,
         client: Entity,
-        entity_buffer: &mut EntityBuffer,
         tick: Tick,
         mutate_index: MutateIndex,
-    ) {
+    ) -> Option<Vec<Entity>> {
         let Some(mutate_info) = self.mutations.remove(&mutate_index) else {
             debug!("received unknown `{mutate_index:?}` from client `{client}`");
-            return;
+            return None;
         };
 
         for entity in &mutate_info.entities {
@@ -114,12 +113,12 @@ impl ClientTicks {
                 *last_tick = mutate_info.tick;
             }
         }
-        entity_buffer.push(mutate_info.entities);
-
         trace!(
             "acknowledged mutate message with `{:?}` from client `{client}`",
             mutate_info.tick,
         );
+
+        Some(mutate_info.entities)
     }
 
     /// Removes a despawned or hidden entity from tracking by this client.


### PR DESCRIPTION
Return the entities instead of pushing them directly into the buffer. This will be needed to access the entities for prioritization, and is also a cleaner API in general.