### PR TITLE
Fix coverage reports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Clippy
-        run: cargo clippy --workspace --examples --all-features --benches --tests -- -D warnings
+        run: cargo clippy --workspace --all-features --tests --benches --examples -- -D warnings
 
       - name: Rustdoc
         run: |
@@ -163,7 +163,7 @@ jobs:
         run: cargo install cargo-tarpaulin
 
       - name: Test
-        run: cargo tarpaulin --benches --all-features --engine llvm --out lcov --exclude-files benches/*
+        run: cargo tarpaulin --all-features --tests --benches --engine llvm --out lcov --exclude-files benches/*
 
         # Can't collect coverage from the example backend,
         # it crashes tarpaulin due to TCP usage.


### PR DESCRIPTION
be98606fa9db867a9b2f3adc654e13ed171b2221 enabled coverage collection for benches, but disabled for everything else. If specific type of coverage is set, tests needs to be enabled explicitly.