### PR TITLE
Accept `impl Into<SocketAddr>` for `ExampleClient::new`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace `ReplicationBundle` with `BundleRules`, which returns only `Vec<ComponentRule>` and uses an associated constant to customize the priority.
 - Hide `ServerEntityMap` mutation methods from public API.
 - Hide `BufferedMutations` from public API.
+- `ExampleClient::new` now accepts `impl Into<SocketAddr>`. This makes it easier for backend developers to port examples since they usually specify IP address.
 
 ## Removed
 

--- a/bevy_replicon_example_backend/examples/deterministic_boids.rs
+++ b/bevy_replicon_example_backend/examples/deterministic_boids.rs
@@ -9,7 +9,10 @@
 //! with authoritative replication for things that can't be simulated deterministically or need
 //! to be hidden from clients.
 
-use std::f32::consts::TAU;
+use std::{
+    f32::consts::TAU,
+    net::{IpAddr, Ipv4Addr},
+};
 
 use bevy::prelude::*;
 use bevy_replicon::{
@@ -77,11 +80,11 @@ fn setup(mut commands: Commands, cli: Res<Cli>) -> Result<()> {
             ));
             spawn_boids(&mut commands);
         }
-        Cli::Client { port } => {
-            info!("connecting to port {port}");
+        Cli::Client { ip, port } => {
+            info!("connecting to {ip}:{port}");
 
             // Backend initialization
-            let client = ExampleClient::new(port)?;
+            let client = ExampleClient::new((ip, port))?;
             let addr = client.local_addr()?;
             commands.insert_resource(client);
 
@@ -274,6 +277,9 @@ enum Cli {
     },
     /// Connect to a host.
     Client {
+        #[arg(short, long, default_value_t = Ipv4Addr::LOCALHOST.into())]
+        ip: IpAddr,
+
         #[arg(short, long, default_value_t = PORT)]
         port: u16,
     },

--- a/bevy_replicon_example_backend/examples/simple_box.rs
+++ b/bevy_replicon_example_backend/examples/simple_box.rs
@@ -1,6 +1,9 @@
 //! A player sends inputs to move a box, and the server replicates the position back.
 
-use std::hash::{DefaultHasher, Hash, Hasher};
+use std::{
+    hash::{DefaultHasher, Hash, Hasher},
+    net::{IpAddr, Ipv4Addr},
+};
 
 use bevy::{
     color::palettes::css::GREEN,
@@ -71,11 +74,11 @@ fn setup(mut commands: Commands, cli: Res<Cli>) -> Result<()> {
                 BoxOwner(ClientId::Server),
             ));
         }
-        Cli::Client { port } => {
-            info!("connecting to port {port}");
+        Cli::Client { ip, port } => {
+            info!("connecting to {ip}:{port}");
 
             // Backend initialization
-            let client = ExampleClient::new(port)?;
+            let client = ExampleClient::new((ip, port))?;
             let addr = client.local_addr()?;
             commands.insert_resource(client);
 
@@ -197,6 +200,9 @@ enum Cli {
     },
     /// Connect to a host.
     Client {
+        #[arg(short, long, default_value_t = Ipv4Addr::LOCALHOST.into())]
+        ip: IpAddr,
+
         #[arg(short, long, default_value_t = PORT)]
         port: u16,
     },

--- a/bevy_replicon_example_backend/examples/tic_tac_toe.rs
+++ b/bevy_replicon_example_backend/examples/tic_tac_toe.rs
@@ -1,7 +1,10 @@
 //! Tic-tac-toe game with optional multiplayer.
 //! Client sends commands and server replicates the state back.
 
-use std::fmt::{self, Formatter};
+use std::{
+    fmt::{self, Formatter},
+    net::{IpAddr, Ipv4Addr},
+};
 
 use bevy::{
     ecs::{relationship::RelatedSpawner, spawn::SpawnWith},
@@ -102,11 +105,11 @@ fn read_cli(mut commands: Commands, cli: Res<Cli>) -> Result<()> {
 
             commands.spawn((LocalPlayer, symbol));
         }
-        Cli::Client { port } => {
-            info!("connecting to port {port}");
+        Cli::Client { ip, port } => {
+            info!("connecting to {ip}:{port}");
 
             // Backend initialization
-            let client = ExampleClient::new(port)?;
+            let client = ExampleClient::new((ip, port))?;
             commands.insert_resource(client);
         }
     }
@@ -524,6 +527,9 @@ enum Cli {
     },
     /// Connect to a host.
     Client {
+        #[arg(short, long, default_value_t = Ipv4Addr::LOCALHOST.into())]
+        ip: IpAddr,
+
         #[arg(short, long, default_value_t = PORT)]
         port: u16,
     },

--- a/bevy_replicon_example_backend/src/client.rs
+++ b/bevy_replicon_example_backend/src/client.rs
@@ -1,6 +1,6 @@
 use std::{
     io,
-    net::{Ipv4Addr, SocketAddr, TcpStream},
+    net::{SocketAddr, TcpStream},
     time::Instant,
 };
 
@@ -105,8 +105,8 @@ pub struct ExampleClient {
 
 impl ExampleClient {
     /// Opens an example client socket connected to a server on the specified port.
-    pub fn new(port: u16) -> io::Result<Self> {
-        let stream = TcpStream::connect((Ipv4Addr::LOCALHOST, port))?;
+    pub fn new(addr: impl Into<SocketAddr>) -> io::Result<Self> {
+        let stream = TcpStream::connect(addr.into())?;
         stream.set_nonblocking(true)?;
         stream.set_nodelay(true)?;
         Ok(Self {

--- a/bevy_replicon_example_backend/tests/backend.rs
+++ b/bevy_replicon_example_backend/tests/backend.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{io, net::Ipv4Addr};
 
 use bevy::prelude::*;
 use bevy_replicon::prelude::*;
@@ -238,7 +238,7 @@ fn client_event() {
 fn setup(server_app: &mut App, client_app: &mut App) -> io::Result<()> {
     let server_socket = ExampleServer::new(0)?;
     let server_addr = server_socket.local_addr()?;
-    let client_socket = ExampleClient::new(server_addr.port())?;
+    let client_socket = ExampleClient::new((Ipv4Addr::LOCALHOST, server_addr.port()))?;
 
     server_app.insert_resource(server_socket);
     client_app.insert_resource(client_socket);


### PR DESCRIPTION
This makes it easier for backend developers to port examples since they usually specify IP address (diffs will be smaller).