### PR TITLE
Rework tick settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rename `RepliconClientStatus` to `ClientState` and `RepliconServerStatus` to `ServerState`. They are now regular Bevy states. As result, we now require `StatesPlugin` to be added. It's present by default in `DefaultPlugins`, but with `MinimalPlugins` you have to add it manually.
-- Replace `TickPolicy` with `TickSchedule` and `ServerPlugin::tick_policy` with `ServerPlugin::tick_schedule`. Instead of default `TickPolicy::MaxTickRate`, it now `TickSchedule::FixedPostUpdate`. Insert `Time<Fixed>` to control how often it runs.
+- Replace `ServerPlugin::tick_policy` with `ServerPlugin::tick_schedule`, which specifies the schedule where the tick increments. By default, it's `FixedPostUpdate`.
 - Make custom entity ser/de compatible with `serde` attributes.
 - All contexts now store `AppTypeRegistry` instead of `TypeRegistry`. To get `TypeRegistry`, call `AppTypeRegistry::read`.
 - All events now use `ClientId` wrapper instead of `Entity`.
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace `ReplicationBundle` with `BundleRules`, which returns only `Vec<ComponentRule>` and uses an associated constant to customize the priority.
 - Hide `ServerEntityMap` mutation methods from public API.
 - Hide `BufferedMutations` from public API.
+- Hide `server::increment_tick` from public API.
 - `ExampleClient::new` now accepts `impl Into<SocketAddr>`. This makes it easier for backend developers to port examples since they usually specify IP address.
 
 ## Removed
@@ -48,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `entity_serde::serialize_entity` and `entity_serde::deserialize_entity`. Use `postcard_utils::entity_to_extend_mut` and `postcard_utils::entity_from_buf` respectively; just swap the argument order.
 - `SERVER`. Use `ClientId::Server` instead.
 - `ReplicationMode::Periodic`. Use `PriorityMap` instead.
+- `TickPolicy`. You now can set the schedule directly or configure how often it runs by inserting `Time::<Fixed>`.
 - All provided run conditions. Just use `in_state` or `OnEnter`/`OnExit` with `ServerState` and `ClientState` instead. `server_or_singleplayer` is just `in_state(ClientState::Disconnected)`.
 
 ## [0.34.4] - 2025-07-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rename `RepliconClientStatus` to `ClientState` and `RepliconServerStatus` to `ServerState`. They are now regular Bevy states. As result, we now require `StatesPlugin` to be added. It's present by default in `DefaultPlugins`, but with `MinimalPlugins` you have to add it manually.
+- Replace `TickPolicy` with `TickSchedule` and `ServerPlugin::tick_policy` with `ServerPlugin::tick_schedule`. Instead of default `TickPolicy::MaxTickRate`, it now `TickSchedule::FixedPostUpdate`. Insert `Time<Fixed>` to control how often it runs.
 - Make custom entity ser/de compatible with `serde` attributes.
 - All contexts now store `AppTypeRegistry` instead of `TypeRegistry`. To get `TypeRegistry`, call `AppTypeRegistry::read`.
 - All events now use `ClientId` wrapper instead of `Entity`.

--- a/benches/replication.rs
+++ b/benches/replication.rs
@@ -1,7 +1,10 @@
 use core::time::Duration;
 
 use bevy::{
-    ecs::component::Mutable, platform::time::Instant, prelude::*, state::app::StatesPlugin,
+    ecs::{component::Mutable, schedule::ScheduleLabel},
+    platform::time::Instant,
+    prelude::*,
+    state::app::StatesPlugin,
 };
 use bevy_replicon::{prelude::*, test_app::ServerTestAppExt};
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
@@ -188,7 +191,7 @@ fn create_app<C: BenchmarkComponent>() -> App {
         MinimalPlugins,
         StatesPlugin,
         RepliconPlugins.set(ServerPlugin {
-            tick_schedule: TickSchedule::PostUpdate,
+            tick_schedule: PostUpdate.intern(),
             ..Default::default()
         }),
     ))

--- a/benches/replication.rs
+++ b/benches/replication.rs
@@ -188,7 +188,7 @@ fn create_app<C: BenchmarkComponent>() -> App {
         MinimalPlugins,
         StatesPlugin,
         RepliconPlugins.set(ServerPlugin {
-            tick_policy: TickPolicy::EveryFrame,
+            tick_schedule: TickSchedule::PostUpdate,
             ..Default::default()
         }),
     ))

--- a/bevy_replicon_example_backend/tests/backend.rs
+++ b/bevy_replicon_example_backend/tests/backend.rs
@@ -15,7 +15,7 @@ fn connect_disconnect() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
             RepliconExampleBackendPlugins,
@@ -59,7 +59,7 @@ fn disconnect_request() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
             RepliconExampleBackendPlugins,
@@ -112,7 +112,7 @@ fn server_stop() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
             RepliconExampleBackendPlugins,
@@ -162,7 +162,7 @@ fn replication() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
             RepliconExampleBackendPlugins,
@@ -190,7 +190,7 @@ fn server_event() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
             RepliconExampleBackendPlugins,
@@ -222,7 +222,7 @@ fn client_event() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
             RepliconExampleBackendPlugins,

--- a/bevy_replicon_example_backend/tests/backend.rs
+++ b/bevy_replicon_example_backend/tests/backend.rs
@@ -1,6 +1,6 @@
 use std::{io, net::Ipv4Addr};
 
-use bevy::{prelude::*, state::app::StatesPlugin};
+use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
 use bevy_replicon::prelude::*;
 use bevy_replicon_example_backend::{ExampleClient, ExampleServer, RepliconExampleBackendPlugins};
 use serde::{Deserialize, Serialize};
@@ -15,7 +15,7 @@ fn connect_disconnect() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
             RepliconExampleBackendPlugins,
@@ -59,7 +59,7 @@ fn disconnect_request() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
             RepliconExampleBackendPlugins,
@@ -112,7 +112,7 @@ fn server_stop() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
             RepliconExampleBackendPlugins,
@@ -162,7 +162,7 @@ fn replication() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
             RepliconExampleBackendPlugins,
@@ -190,7 +190,7 @@ fn server_event() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
             RepliconExampleBackendPlugins,
@@ -222,7 +222,7 @@ fn client_event() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
             RepliconExampleBackendPlugins,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,6 @@ app.insert_resource(Time::from_hz(30.0)) // Run 30 times per second.
 ```
 
 You can also configure the schedule via [`ServerPlugin::tick_schedule`].
-For example, you can make it run every frame for tests.
 
 ### Entities
 
@@ -735,7 +734,7 @@ pub mod prelude {
 
     #[cfg(feature = "server")]
     pub use super::server::{
-        AuthorizedClient, PriorityMap, ServerPlugin, ServerSet, TickSchedule, VisibilityPolicy,
+        AuthorizedClient, PriorityMap, ServerPlugin, ServerSet, VisibilityPolicy,
         client_entity_map::ClientEntityMap, client_visibility::ClientVisibility,
         event::ServerEventPlugin, related_entities::SyncRelatedAppExt,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,30 +113,25 @@ For implementation details see [`ServerChannel`](shared::backend::channels::Serv
 
 ### Tick rate
 
-Typically updates are not sent every frame. Instead, they are sent at a certain interval
-to save traffic.
+By default, updates are not sent every frame in order to save bandwidth. Replication runs
+in [`ServerSet::Send`] whenever the [`ServerTick`](server::server_tick::ServerTick) resource
+changes and if the state is [`ServerState::Running`].
 
-On server current tick stored in [`RepliconTick`] resource. Replication runs when this resource changes.
+By default, the tick is incremented in [`FixedPostUpdate`] each time [`FixedMain`](bevy::app::FixedMain)
+runs. You can configure how often it runs by inserting [`Time<Fixed>`], which is 64 Hz by default.
 
-You can use [`TickPolicy::Manual`] and then add the [`increment_tick`](server::increment_tick)
-system to [`FixedUpdate`]:
+```rust
+use bevy::{prelude::*, state::app::StatesPlugin};
+use bevy_replicon::prelude::*;
 
-```
-# use bevy::{prelude::*, state::app::StatesPlugin};
-# use bevy_replicon::prelude::*;
 # let mut app = App::new();
-# app.add_plugins(StatesPlugin);
-app.add_plugins(
-    RepliconPlugins
-        .build()
-        .disable::<ClientPlugin>()
-        .set(ServerPlugin {
-            tick_policy: TickPolicy::Manual,
-            ..Default::default()
-        }),
-)
-.add_systems(FixedPreUpdate, bevy_replicon::server::increment_tick);
+// `Time::from_hz` is implemented only for `Fixed`, so the type is inferred.
+app.insert_resource(Time::from_hz(30.0)) // Run 30 times per second.
+    .add_plugins((MinimalPlugins, StatesPlugin, RepliconPlugins));
 ```
+
+You can also configure the schedule via [`ServerPlugin::tick_schedule`].
+For example, you can make it run every frame for tests.
 
 ### Entities
 
@@ -740,7 +735,7 @@ pub mod prelude {
 
     #[cfg(feature = "server")]
     pub use super::server::{
-        AuthorizedClient, PriorityMap, ServerPlugin, ServerSet, TickPolicy, VisibilityPolicy,
+        AuthorizedClient, PriorityMap, ServerPlugin, ServerSet, TickSchedule, VisibilityPolicy,
         client_entity_map::ClientEntityMap, client_visibility::ClientVisibility,
         event::ServerEventPlugin, related_entities::SyncRelatedAppExt,
     };

--- a/src/server/server_tick.rs
+++ b/src/server/server_tick.rs
@@ -9,8 +9,9 @@ use crate::prelude::*;
 /// available to the client in the custom deserialization, despawn, and component
 /// removal functions.
 ///
-/// The server sends replication data in [`ServerSet::Send`] any time this resource changes.
-/// You can configure when the tick is incremented via [`ServerPlugin::tick_schedule`].
+/// The server sends replication data in [`ServerSet::Send`] when the state is
+/// [`ServerState::Running`] any time this resource changes. You can configure
+/// when the tick is incremented via [`ServerPlugin::tick_schedule`].
 ///
 /// Note that component mutations are replicated over the unreliable channel.
 /// If a component mutation message is lost, the mutation will not be resent

--- a/src/server/server_tick.rs
+++ b/src/server/server_tick.rs
@@ -5,14 +5,16 @@ use crate::prelude::*;
 
 /// Stores current [`RepliconTick`].
 ///
-/// Used only on the server. The [`ServerPlugin`] sends replication data
-/// in [`PostUpdate`] any time this resource changes.
-/// By default, its incremented in [`PostUpdate`] per the [`TickPolicy`].
+/// Used only on the server. Can represent your simulation step, and is made
+/// available to the client in the custom deserialization, despawn, and component
+/// removal functions.
 ///
-/// If you set [`TickPolicy::Manual`], you can increment this resource
-/// at the start of your game loop (e.g. inside [`FixedMain`](bevy::app::FixedMain)).
-/// This value can be used to represent your simulation step, and is made available to the client in
-/// the custom deserialization, despawn, and component removal functions.
+/// The server sends replication data in [`ServerSet::Send`] any time this resource changes.
+/// You can configure when the tick is incremented via [`ServerPlugin::tick_schedule`].
+///
+/// Note that component mutations are replicated over the unreliable channel.
+/// If a component mutation message is lost, the mutation will not be resent
+/// until the server's replication system runs again.
 ///
 /// See [`ServerUpdateTick`](crate::client::ServerUpdateTick) for tracking the last received
 /// tick on clients.

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -19,7 +19,7 @@ for app in [&mut server_app, &mut client_app] {
         StatesPlugin,
         // No messaging library plugin required.
         RepliconPlugins.set(ServerPlugin {
-            tick_policy: TickPolicy::EveryFrame, // To tick each app update.
+            tick_schedule: TickSchedule::PostUpdate, // To tick each app update.
             ..Default::default()
         }),
     ))

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -8,7 +8,7 @@ Extension for [`App`] to communicate with other instances like it's a server.
 # Example
 
 ```
-use bevy::{prelude::*, state::app::StatesPlugin};
+use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{prelude::*, test_app::ServerTestAppExt};
 
 let mut server_app = App::new();
@@ -19,7 +19,7 @@ for app in [&mut server_app, &mut client_app] {
         StatesPlugin,
         // No messaging library plugin required.
         RepliconPlugins.set(ServerPlugin {
-            tick_schedule: TickSchedule::PostUpdate, // To tick each app update.
+            tick_schedule: PostUpdate.intern(), // Tick each app update.
             ..Default::default()
         }),
     ))

--- a/tests/bidirectional_event.rs
+++ b/tests/bidirectional_event.rs
@@ -48,7 +48,7 @@ fn trigger() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))

--- a/tests/bidirectional_event.rs
+++ b/tests/bidirectional_event.rs
@@ -1,4 +1,8 @@
-use bevy::{ecs::event::Events, prelude::*, state::app::StatesPlugin};
+use bevy::{
+    ecs::{event::Events, schedule::ScheduleLabel},
+    prelude::*,
+    state::app::StatesPlugin,
+};
 use bevy_replicon::{prelude::*, test_app::ServerTestAppExt};
 use serde::{Deserialize, Serialize};
 use test_log::test;
@@ -48,7 +52,7 @@ fn trigger() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))

--- a/tests/client_event.rs
+++ b/tests/client_event.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    ecs::{entity::MapEntities, event::Events},
+    ecs::{entity::MapEntities, event::Events, schedule::ScheduleLabel},
     prelude::*,
     state::app::StatesPlugin,
     time::TimePlugin,
@@ -21,7 +21,7 @@ fn channels() {
         MinimalPlugins,
         StatesPlugin,
         RepliconPlugins.set(ServerPlugin {
-            tick_schedule: TickSchedule::PostUpdate,
+            tick_schedule: PostUpdate.intern(),
             ..Default::default()
         }),
     ))
@@ -67,7 +67,7 @@ fn mapped() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))

--- a/tests/client_event.rs
+++ b/tests/client_event.rs
@@ -21,7 +21,7 @@ fn channels() {
         MinimalPlugins,
         StatesPlugin,
         RepliconPlugins.set(ServerPlugin {
-            tick_policy: TickPolicy::EveryFrame,
+            tick_schedule: TickSchedule::PostUpdate,
             ..Default::default()
         }),
     ))
@@ -67,7 +67,7 @@ fn mapped() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))

--- a/tests/client_trigger.rs
+++ b/tests/client_trigger.rs
@@ -37,7 +37,7 @@ fn with_target() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -82,7 +82,7 @@ fn mapped() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))

--- a/tests/client_trigger.rs
+++ b/tests/client_trigger.rs
@@ -1,4 +1,9 @@
-use bevy::{ecs::entity::MapEntities, prelude::*, state::app::StatesPlugin, time::TimePlugin};
+use bevy::{
+    ecs::{entity::MapEntities, schedule::ScheduleLabel},
+    prelude::*,
+    state::app::StatesPlugin,
+    time::TimePlugin,
+};
 use bevy_replicon::{
     prelude::*, shared::server_entity_map::ServerEntityMap, test_app::ServerTestAppExt,
 };
@@ -37,7 +42,7 @@ fn with_target() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -82,7 +87,7 @@ fn mapped() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use bevy::{prelude::*, state::app::StatesPlugin};
+use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{
     prelude::*,
     server::server_tick::ServerTick,
@@ -44,7 +44,7 @@ fn server_start_stop() {
                     auth_method: AuthMethod::Custom,
                 })
                 .set(ServerPlugin {
-                    tick_schedule: TickSchedule::PostUpdate,
+                    tick_schedule: PostUpdate.intern(),
                     ..Default::default()
                 }),
         ))

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -44,7 +44,7 @@ fn server_start_stop() {
                     auth_method: AuthMethod::Custom,
                 })
                 .set(ServerPlugin {
-                    tick_policy: TickPolicy::EveryFrame,
+                    tick_schedule: TickSchedule::PostUpdate,
                     ..Default::default()
                 }),
         ))

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, state::app::StatesPlugin};
+use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{
     prelude::*, shared::server_entity_map::ServerEntityMap, test_app::ServerTestAppExt,
 };
@@ -14,7 +14,7 @@ fn single() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -59,7 +59,7 @@ fn with_relations() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -99,7 +99,7 @@ fn after_spawn() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -132,7 +132,7 @@ fn hidden() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 visibility_policy: VisibilityPolicy::Whitelist, // Hide all spawned entities by default.
                 ..Default::default()
             }),

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -14,7 +14,7 @@ fn single() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -59,7 +59,7 @@ fn with_relations() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -99,7 +99,7 @@ fn after_spawn() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -132,7 +132,7 @@ fn hidden() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 visibility_policy: VisibilityPolicy::Whitelist, // Hide all spawned entities by default.
                 ..Default::default()
             }),

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -1,4 +1,8 @@
-use bevy::{ecs::system::SystemState, prelude::*, state::app::StatesPlugin};
+use bevy::{
+    ecs::{schedule::ScheduleLabel, system::SystemState},
+    prelude::*,
+    state::app::StatesPlugin,
+};
 use bevy_replicon::{
     client::confirm_history::{ConfirmHistory, EntityReplicated},
     prelude::*,
@@ -25,7 +29,7 @@ fn table_storage() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -64,7 +68,7 @@ fn sparse_set_storage() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -103,7 +107,7 @@ fn immutable() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -155,7 +159,7 @@ fn mapped_existing_entity() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -206,7 +210,7 @@ fn mapped_new_entity() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -253,7 +257,7 @@ fn multiple_components() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -300,7 +304,7 @@ fn command_fns() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -342,7 +346,7 @@ fn marker() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -393,7 +397,7 @@ fn group() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -432,7 +436,7 @@ fn not_replicated() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -467,7 +471,7 @@ fn after_removal() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -521,7 +525,7 @@ fn before_started_replication() {
                     auth_method: AuthMethod::Custom,
                 })
                 .set(ServerPlugin {
-                    tick_schedule: TickSchedule::PostUpdate,
+                    tick_schedule: PostUpdate.intern(),
                     ..Default::default()
                 }),
         ))
@@ -572,7 +576,7 @@ fn after_started_replication() {
                     auth_method: AuthMethod::Custom,
                 })
                 .set(ServerPlugin {
-                    tick_schedule: TickSchedule::PostUpdate,
+                    tick_schedule: PostUpdate.intern(),
                     ..Default::default()
                 }),
         ))
@@ -613,7 +617,7 @@ fn confirm_history() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -25,7 +25,7 @@ fn table_storage() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -64,7 +64,7 @@ fn sparse_set_storage() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -103,7 +103,7 @@ fn immutable() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -155,7 +155,7 @@ fn mapped_existing_entity() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -206,7 +206,7 @@ fn mapped_new_entity() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -253,7 +253,7 @@ fn multiple_components() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -300,7 +300,7 @@ fn command_fns() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -342,7 +342,7 @@ fn marker() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -393,7 +393,7 @@ fn group() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -432,7 +432,7 @@ fn not_replicated() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -467,7 +467,7 @@ fn after_removal() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -521,7 +521,7 @@ fn before_started_replication() {
                     auth_method: AuthMethod::Custom,
                 })
                 .set(ServerPlugin {
-                    tick_policy: TickPolicy::EveryFrame,
+                    tick_schedule: TickSchedule::PostUpdate,
                     ..Default::default()
                 }),
         ))
@@ -572,7 +572,7 @@ fn after_started_replication() {
                     auth_method: AuthMethod::Custom,
                 })
                 .set(ServerPlugin {
-                    tick_policy: TickPolicy::EveryFrame,
+                    tick_schedule: TickSchedule::PostUpdate,
                     ..Default::default()
                 }),
         ))
@@ -613,7 +613,7 @@ fn confirm_history() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))

--- a/tests/mutate_ticks.rs
+++ b/tests/mutate_ticks.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, state::app::StatesPlugin};
+use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{
     client::server_mutate_ticks::{MutateTickReceived, ServerMutateTicks},
     prelude::*,
@@ -18,7 +18,7 @@ fn without_changes() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -54,7 +54,7 @@ fn one_message() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -122,7 +122,7 @@ fn multiple_messages() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))

--- a/tests/mutate_ticks.rs
+++ b/tests/mutate_ticks.rs
@@ -18,7 +18,7 @@ fn without_changes() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -54,7 +54,7 @@ fn one_message() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -122,7 +122,7 @@ fn multiple_messages() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))

--- a/tests/mutations.rs
+++ b/tests/mutations.rs
@@ -1,7 +1,7 @@
 use core::time::Duration;
 use test_log::test;
 
-use bevy::{prelude::*, state::app::StatesPlugin};
+use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{
     client::{
         ServerUpdateTick,
@@ -31,7 +31,7 @@ fn small_component() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -79,7 +79,7 @@ fn package_size_component() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -133,7 +133,7 @@ fn many_components() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -190,7 +190,7 @@ fn once() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -238,7 +238,7 @@ fn filtered() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -298,7 +298,7 @@ fn related() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -345,7 +345,7 @@ fn command_fns() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -395,7 +395,7 @@ fn marker() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -456,7 +456,7 @@ fn marker_with_history() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -533,7 +533,7 @@ fn marker_with_history_consume() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -624,7 +624,7 @@ fn marker_with_history_old_update() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -702,7 +702,7 @@ fn many_entities() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -756,7 +756,7 @@ fn with_insertion() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -802,7 +802,7 @@ fn with_removal() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -848,7 +848,7 @@ fn with_despawn() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -898,7 +898,7 @@ fn buffering() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -957,7 +957,7 @@ fn old_ignored() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -1025,7 +1025,7 @@ fn acknowledgment() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 mutations_timeout: Duration::ZERO, // Will cause dropping updates after each frame.
                 ..Default::default()
             }),
@@ -1104,7 +1104,7 @@ fn confirm_history() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -1171,7 +1171,7 @@ fn after_disconnect() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))

--- a/tests/mutations.rs
+++ b/tests/mutations.rs
@@ -31,7 +31,7 @@ fn small_component() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -79,7 +79,7 @@ fn package_size_component() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -133,7 +133,7 @@ fn many_components() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -190,7 +190,7 @@ fn once() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -238,7 +238,7 @@ fn filtered() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -298,7 +298,7 @@ fn related() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -345,7 +345,7 @@ fn command_fns() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -395,7 +395,7 @@ fn marker() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -456,7 +456,7 @@ fn marker_with_history() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -533,7 +533,7 @@ fn marker_with_history_consume() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -624,7 +624,7 @@ fn marker_with_history_old_update() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -702,7 +702,7 @@ fn many_entities() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -756,7 +756,7 @@ fn with_insertion() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -802,7 +802,7 @@ fn with_removal() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -848,7 +848,7 @@ fn with_despawn() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -898,7 +898,7 @@ fn buffering() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -957,7 +957,7 @@ fn old_ignored() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -1025,7 +1025,7 @@ fn acknowledgment() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 mutations_timeout: Duration::ZERO, // Will cause dropping updates after each frame.
                 ..Default::default()
             }),
@@ -1104,7 +1104,7 @@ fn confirm_history() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -1171,7 +1171,7 @@ fn after_disconnect() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))

--- a/tests/priority.rs
+++ b/tests/priority.rs
@@ -1,6 +1,6 @@
 use test_log::test;
 
-use bevy::{prelude::*, state::app::StatesPlugin};
+use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{
     prelude::*,
     test_app::{ServerTestAppExt, TestClientEntity},
@@ -16,7 +16,7 @@ fn regular() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -76,7 +76,7 @@ fn with_miss() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))

--- a/tests/priority.rs
+++ b/tests/priority.rs
@@ -16,7 +16,7 @@ fn regular() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -76,7 +76,7 @@ fn with_miss() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, state::app::StatesPlugin};
+use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{
     client::confirm_history::{ConfirmHistory, EntityReplicated},
     prelude::*,
@@ -22,7 +22,7 @@ fn single() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -63,7 +63,7 @@ fn multiple() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -112,7 +112,7 @@ fn command_fns() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -154,7 +154,7 @@ fn marker() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -204,7 +204,7 @@ fn group() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -250,7 +250,7 @@ fn not_replicated() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -302,7 +302,7 @@ fn after_insertion() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -345,7 +345,7 @@ fn with_spawn() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -376,7 +376,7 @@ fn with_despawn() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -419,7 +419,7 @@ fn confirm_history() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -486,7 +486,7 @@ fn hidden() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 visibility_policy: VisibilityPolicy::Whitelist, // Hide all spawned entities by default.
                 ..Default::default()
             }),

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -22,7 +22,7 @@ fn single() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -63,7 +63,7 @@ fn multiple() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -112,7 +112,7 @@ fn command_fns() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -154,7 +154,7 @@ fn marker() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -204,7 +204,7 @@ fn group() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -250,7 +250,7 @@ fn not_replicated() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -302,7 +302,7 @@ fn after_insertion() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -345,7 +345,7 @@ fn with_spawn() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -376,7 +376,7 @@ fn with_despawn() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -419,7 +419,7 @@ fn confirm_history() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -486,7 +486,7 @@ fn hidden() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 visibility_policy: VisibilityPolicy::Whitelist, // Hide all spawned entities by default.
                 ..Default::default()
             }),

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -23,7 +23,7 @@ fn channels() {
         MinimalPlugins,
         StatesPlugin,
         RepliconPlugins.set(ServerPlugin {
-            tick_policy: TickPolicy::EveryFrame,
+            tick_schedule: TickSchedule::PostUpdate,
             ..Default::default()
         }),
     ))
@@ -45,7 +45,7 @@ fn regular() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -91,7 +91,7 @@ fn mapped() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -139,7 +139,7 @@ fn without_plugins() {
             RepliconPlugins
                 .build()
                 .set(ServerPlugin {
-                    tick_policy: TickPolicy::EveryFrame,
+                    tick_schedule: TickSchedule::PostUpdate,
                     ..Default::default()
                 })
                 .disable::<ClientPlugin>()
@@ -195,7 +195,7 @@ fn local_resending() {
         TimePlugin,
         StatesPlugin,
         RepliconPlugins.set(ServerPlugin {
-            tick_policy: TickPolicy::EveryFrame,
+            tick_schedule: TickSchedule::PostUpdate,
             ..Default::default()
         }),
     ))
@@ -238,7 +238,7 @@ fn server_buffering() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::Manual, // To artificially delay replication after sending.
+                tick_schedule: TickSchedule::Custom, // To artificially delay replication after sending.
                 ..Default::default()
             }),
         ))
@@ -285,7 +285,7 @@ fn client_queue() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -336,7 +336,7 @@ fn client_queue_and_mapping() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -400,7 +400,7 @@ fn multiple_client_queues() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -463,7 +463,7 @@ fn independent() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -536,7 +536,7 @@ fn before_started_replication() {
             StatesPlugin,
             RepliconPlugins
                 .set(ServerPlugin {
-                    tick_policy: TickPolicy::EveryFrame,
+                    tick_schedule: TickSchedule::PostUpdate,
                     ..Default::default()
                 })
                 .set(RepliconSharedPlugin {
@@ -580,7 +580,7 @@ fn independent_before_started_replication() {
             StatesPlugin,
             RepliconPlugins
                 .set(ServerPlugin {
-                    tick_policy: TickPolicy::EveryFrame,
+                    tick_schedule: TickSchedule::PostUpdate,
                     ..Default::default()
                 })
                 .set(RepliconSharedPlugin {
@@ -629,7 +629,7 @@ fn different_ticks() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    ecs::{entity::MapEntities, event::Events},
+    ecs::{entity::MapEntities, event::Events, schedule::ScheduleLabel},
     prelude::*,
     state::app::StatesPlugin,
     time::TimePlugin,
@@ -23,7 +23,7 @@ fn channels() {
         MinimalPlugins,
         StatesPlugin,
         RepliconPlugins.set(ServerPlugin {
-            tick_schedule: TickSchedule::PostUpdate,
+            tick_schedule: PostUpdate.intern(),
             ..Default::default()
         }),
     ))
@@ -45,7 +45,7 @@ fn regular() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -91,7 +91,7 @@ fn mapped() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -139,7 +139,7 @@ fn without_plugins() {
             RepliconPlugins
                 .build()
                 .set(ServerPlugin {
-                    tick_schedule: TickSchedule::PostUpdate,
+                    tick_schedule: PostUpdate.intern(),
                     ..Default::default()
                 })
                 .disable::<ClientPlugin>()
@@ -195,7 +195,7 @@ fn local_resending() {
         TimePlugin,
         StatesPlugin,
         RepliconPlugins.set(ServerPlugin {
-            tick_schedule: TickSchedule::PostUpdate,
+            tick_schedule: PostUpdate.intern(),
             ..Default::default()
         }),
     ))
@@ -234,16 +234,9 @@ fn server_buffering() {
     let mut server_app = App::new();
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((
-            MinimalPlugins,
-            StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::Custom, // To artificially delay replication after sending.
-                ..Default::default()
-            }),
-        ))
-        .add_server_event::<TestEvent>(Channel::Ordered)
-        .finish();
+        app.add_plugins((MinimalPlugins, StatesPlugin, RepliconPlugins))
+            .add_server_event::<TestEvent>(Channel::Ordered)
+            .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -285,7 +278,7 @@ fn client_queue() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -336,7 +329,7 @@ fn client_queue_and_mapping() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -400,7 +393,7 @@ fn multiple_client_queues() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -463,7 +456,7 @@ fn independent() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -536,7 +529,7 @@ fn before_started_replication() {
             StatesPlugin,
             RepliconPlugins
                 .set(ServerPlugin {
-                    tick_schedule: TickSchedule::PostUpdate,
+                    tick_schedule: PostUpdate.intern(),
                     ..Default::default()
                 })
                 .set(RepliconSharedPlugin {
@@ -580,7 +573,7 @@ fn independent_before_started_replication() {
             StatesPlugin,
             RepliconPlugins
                 .set(ServerPlugin {
-                    tick_schedule: TickSchedule::PostUpdate,
+                    tick_schedule: PostUpdate.intern(),
                     ..Default::default()
                 })
                 .set(RepliconSharedPlugin {
@@ -629,7 +622,7 @@ fn different_ticks() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))

--- a/tests/server_trigger.rs
+++ b/tests/server_trigger.rs
@@ -15,7 +15,7 @@ fn regular() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -48,7 +48,7 @@ fn with_target() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -93,7 +93,7 @@ fn mapped() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -138,7 +138,7 @@ fn without_plugins() {
             RepliconPlugins
                 .build()
                 .set(ServerPlugin {
-                    tick_policy: TickPolicy::EveryFrame,
+                    tick_schedule: TickSchedule::PostUpdate,
                     ..Default::default()
                 })
                 .disable::<ClientPlugin>()
@@ -181,7 +181,7 @@ fn local_resending() {
         TimePlugin,
         StatesPlugin,
         RepliconPlugins.set(ServerPlugin {
-            tick_policy: TickPolicy::EveryFrame,
+            tick_schedule: TickSchedule::PostUpdate,
             ..Default::default()
         }),
     ))
@@ -212,7 +212,7 @@ fn independent() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))

--- a/tests/server_trigger.rs
+++ b/tests/server_trigger.rs
@@ -1,4 +1,9 @@
-use bevy::{ecs::entity::MapEntities, prelude::*, state::app::StatesPlugin, time::TimePlugin};
+use bevy::{
+    ecs::{entity::MapEntities, schedule::ScheduleLabel},
+    prelude::*,
+    state::app::StatesPlugin,
+    time::TimePlugin,
+};
 use bevy_replicon::{
     client::ServerUpdateTick, prelude::*, shared::server_entity_map::ServerEntityMap,
     test_app::ServerTestAppExt,
@@ -15,7 +20,7 @@ fn regular() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -48,7 +53,7 @@ fn with_target() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -93,7 +98,7 @@ fn mapped() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -138,7 +143,7 @@ fn without_plugins() {
             RepliconPlugins
                 .build()
                 .set(ServerPlugin {
-                    tick_schedule: TickSchedule::PostUpdate,
+                    tick_schedule: PostUpdate.intern(),
                     ..Default::default()
                 })
                 .disable::<ClientPlugin>()
@@ -181,7 +186,7 @@ fn local_resending() {
         TimePlugin,
         StatesPlugin,
         RepliconPlugins.set(ServerPlugin {
-            tick_schedule: TickSchedule::PostUpdate,
+            tick_schedule: PostUpdate.intern(),
             ..Default::default()
         }),
     ))
@@ -212,7 +217,7 @@ fn independent() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, state::app::StatesPlugin};
+use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{
     client::confirm_history::ConfirmHistory,
     prelude::*,
@@ -17,7 +17,7 @@ fn empty() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -60,7 +60,7 @@ fn with_component() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -89,7 +89,7 @@ fn with_multiple_components() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -126,7 +126,7 @@ fn with_old_component() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -170,7 +170,7 @@ fn before_connection() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -199,7 +199,7 @@ fn pre_spawn() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))
@@ -266,7 +266,7 @@ fn after_despawn() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -17,7 +17,7 @@ fn empty() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -60,7 +60,7 @@ fn with_component() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -89,7 +89,7 @@ fn with_multiple_components() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -126,7 +126,7 @@ fn with_old_component() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -170,7 +170,7 @@ fn before_connection() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -199,7 +199,7 @@ fn pre_spawn() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))
@@ -266,7 +266,7 @@ fn after_despawn() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))

--- a/tests/stats.rs
+++ b/tests/stats.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, state::app::StatesPlugin};
+use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{
     prelude::*,
     test_app::{ServerTestAppExt, TestClientEntity},
@@ -15,7 +15,7 @@ fn client_stats() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 ..Default::default()
             }),
         ))

--- a/tests/stats.rs
+++ b/tests/stats.rs
@@ -15,7 +15,7 @@ fn client_stats() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 ..Default::default()
             }),
         ))

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -15,7 +15,7 @@ fn empty_blacklist() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 visibility_policy: VisibilityPolicy::Blacklist,
                 ..Default::default()
             }),
@@ -47,7 +47,7 @@ fn blacklist() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 visibility_policy: VisibilityPolicy::Blacklist,
                 ..Default::default()
             }),
@@ -104,7 +104,7 @@ fn blacklist_with_despawn() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 visibility_policy: VisibilityPolicy::Blacklist,
                 ..Default::default()
             }),
@@ -145,7 +145,7 @@ fn empty_whitelist() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 visibility_policy: VisibilityPolicy::Whitelist,
                 ..Default::default()
             }),
@@ -179,7 +179,7 @@ fn whitelist() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 visibility_policy: VisibilityPolicy::Whitelist,
                 ..Default::default()
             }),
@@ -239,7 +239,7 @@ fn whitelist_with_despawn() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
+                tick_schedule: TickSchedule::PostUpdate,
                 visibility_policy: VisibilityPolicy::Whitelist,
                 ..Default::default()
             }),

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, state::app::StatesPlugin};
+use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{
     prelude::*,
     test_app::{ServerTestAppExt, TestClientEntity},
@@ -15,7 +15,7 @@ fn empty_blacklist() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 visibility_policy: VisibilityPolicy::Blacklist,
                 ..Default::default()
             }),
@@ -47,7 +47,7 @@ fn blacklist() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 visibility_policy: VisibilityPolicy::Blacklist,
                 ..Default::default()
             }),
@@ -104,7 +104,7 @@ fn blacklist_with_despawn() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 visibility_policy: VisibilityPolicy::Blacklist,
                 ..Default::default()
             }),
@@ -145,7 +145,7 @@ fn empty_whitelist() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 visibility_policy: VisibilityPolicy::Whitelist,
                 ..Default::default()
             }),
@@ -179,7 +179,7 @@ fn whitelist() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 visibility_policy: VisibilityPolicy::Whitelist,
                 ..Default::default()
             }),
@@ -239,7 +239,7 @@ fn whitelist_with_despawn() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: TickSchedule::PostUpdate,
+                tick_schedule: PostUpdate.intern(),
                 visibility_policy: VisibilityPolicy::Whitelist,
                 ..Default::default()
             }),


### PR DESCRIPTION
Requires #565.

Set the schedule on which the tick increments directly. And it's `FixedPostUpdate` by default. Users can configure how often it runs via `Time<Fixed>`.