### PR TITLE
Add `replicate_as`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `compact_entity` with functions for `serde` to pack `Entity` more efficienly.
 - `postcard_utils::entity_to_extend_mut` and `postcard_utils::entity_from_buf` helpers that use `compact_entity`.
 - `AppRuleExt::replicate_bundle_with` to customize the priority of the bundle.
+- `AppRuleExt::replicate_as*` functions to convert the component into a different struct before serialization and after deserialiation.
 
 ### Changed
 

--- a/bevy_replicon_example_backend/examples/authoritative_rts.rs
+++ b/bevy_replicon_example_backend/examples/authoritative_rts.rs
@@ -25,12 +25,7 @@ use bevy::{
     prelude::*,
     render::primitives::Aabb,
 };
-use bevy_replicon::{
-    bytes::Bytes,
-    postcard_utils,
-    prelude::*,
-    shared::replication::registry::ctx::{SerializeCtx, WriteCtx},
-};
+use bevy_replicon::prelude::*;
 use bevy_replicon_example_backend::{ExampleClient, ExampleServer, RepliconExampleBackendPlugins};
 use clap::{Parser, ValueEnum};
 use pathfinding::prelude::*;
@@ -48,8 +43,7 @@ fn main() {
         .init_resource::<ClientTeams>()
         .replicate::<Unit>()
         .replicate::<Command>()
-        // Customize serialization to skip `scale` and avoid sending Z axis.
-        .replicate_with(RuleFns::new(serialize_transform, deserialize_transform))
+        .replicate_as::<Transform, Transform2DWithoutScale>()
         .add_client_trigger::<TeamRequest>(Channel::Unordered)
         .add_client_trigger::<UnitSpawn>(Channel::Unordered)
         .add_mapped_client_trigger::<UnitsMove>(Channel::Unordered)
@@ -746,20 +740,28 @@ enum Command {
 #[require(Gizmo)]
 struct Selected;
 
-/// Serializes [`Transform`] without [`Transform::scale`] and Z axis.
-fn serialize_transform(
-    _ctx: &SerializeCtx,
-    transform: &Transform,
-    message: &mut Vec<u8>,
-) -> Result<()> {
-    postcard_utils::to_extend_mut(&transform.translation.truncate(), message)?;
-    postcard_utils::to_extend_mut(&transform.rotation, message)?;
-    Ok(())
+/// Helper to send [`Transform`] without [`Transform::scale`] and Z axis.
+#[derive(Serialize, Deserialize, Clone, Copy)]
+struct Transform2DWithoutScale {
+    translation: Vec2,
+    rotation: Quat,
 }
 
-/// Deserializes [`Transform`] without [`Transform::scale`] and Z axis.
-fn deserialize_transform(_ctx: &mut WriteCtx, message: &mut Bytes) -> Result<Transform> {
-    let translation: Vec2 = postcard_utils::from_buf(message)?;
-    let rotation = postcard_utils::from_buf(message)?;
-    Ok(Transform::from_translation(translation.extend(0.0)).with_rotation(rotation))
+impl From<Transform> for Transform2DWithoutScale {
+    fn from(value: Transform) -> Self {
+        Self {
+            translation: value.translation.truncate(),
+            rotation: value.rotation,
+        }
+    }
+}
+
+impl From<Transform2DWithoutScale> for Transform {
+    fn from(value: Transform2DWithoutScale) -> Self {
+        Self {
+            translation: value.translation.extend(0.0),
+            rotation: value.rotation,
+            ..Default::default()
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,7 @@ In order to serialize Bevy components you need to enable the `serialize` feature
 
 If your component doesn't implement serde traits or you want to customize the serialization
 (for example, quantize, skip some fields or apply compression), you can use
-[`AppRuleExt::replicate_with`].
+[`AppRuleExt::replicate_as`] or [`AppRuleExt::replicate_with`].
 
 You can also create a rule for multiple components. Use [`AppRuleExt::replicate_bundle`],
 or pass a tuple of [`RuleFns`] to [`AppRuleExt::replicate_with`]. The components will only

--- a/src/shared/replication/registry/rule_fns.rs
+++ b/src/shared/replication/registry/rule_fns.rs
@@ -83,7 +83,7 @@ pub struct RuleFns<C> {
 impl<C: Component> RuleFns<C> {
     /// Creates a new instance.
     ///
-    /// For more details see [`AppRuleExt::replicate_with`].
+    /// For more details see [`AppRuleExt::replicate_with`](crate::prelude::AppRuleExt::replicate_with).
     pub fn new(serialize: SerializeFn<C>, deserialize: DeserializeFn<C>) -> Self {
         Self {
             serialize,
@@ -96,7 +96,7 @@ impl<C: Component> RuleFns<C> {
     /// Like [`Self::default`], but converts the component into `T` before serialization
     /// and back into `C` after deserialization.
     ///
-    /// For more details see [`AppRuleExt::replicate_as`].
+    /// For more details see [`AppRuleExt::replicate_as`](crate::prelude::AppRuleExt::replicate_as).
     pub fn new_as<T>() -> Self
     where
         T: Serialize + DeserializeOwned,

--- a/src/shared/replication/rules.rs
+++ b/src/shared/replication/rules.rs
@@ -39,6 +39,116 @@ pub trait AppRuleExt {
         self.replicate_once_filtered::<C, ()>()
     }
 
+    /// Like [`Self::replicate`], but converts the component into `T` before serialization
+    /// and back into `C` after deserialization.
+    ///
+    /// Useful for customizing how the component is sent over the network.
+    /// In some cases, this is more convenient than passing custom ser/de functions
+    /// with [`Self::replicate_with`], because you only need to implement
+    /// [`From<C>`] for `T` and [`From<T>`] for `C`.
+    ///
+    /// # Examples
+    ///
+    /// Quantize position:
+    ///
+    /// ```
+    /// # use bevy::state::app::StatesPlugin;
+    /// use bevy::{math::I16Vec2, prelude::*};
+    /// use bevy_replicon::prelude::*;
+    /// use serde::{Deserialize, Serialize};
+    ///
+    /// # let mut app = App::new();
+    /// # app.add_plugins((StatesPlugin, RepliconPlugins));
+    /// app.replicate_as::<Position, QuantizedPosition>();
+    ///
+    /// #[derive(Component, Deref, Clone, Copy)]
+    /// struct Position(Vec2);
+    ///
+    /// /// Quantized representation of [`Position`] sent over the network.
+    /// #[derive(Deref, Serialize, Deserialize)]
+    /// struct QuantizedPosition(I16Vec2);
+    ///
+    /// /// Scale factor for quantizing.
+    /// ///
+    /// /// Each unit in world space is multiplied by this factor before rounding.
+    /// /// With this scale we keep two decimal places of precision (0.01 units).
+    /// /// The representable range is from [`i16::MIN`] to [`i16::MAX`] divided by this value,
+    /// /// which is `-327.68..=327.67` per axis. Values outside this range will overflow,
+    /// /// so world positions should stay within it.
+    /// const SCALE: f32 = 100.0;
+    ///
+    /// impl From<Position> for QuantizedPosition {
+    ///     fn from(position: Position) -> Self {
+    ///         Self((*position * SCALE).round().as_i16vec2())
+    ///     }
+    /// }
+    ///
+    /// impl From<QuantizedPosition> for Position {
+    ///     fn from(position: QuantizedPosition) -> Self {
+    ///         Position(position.as_vec2() / SCALE)
+    ///     }
+    /// }
+    ///
+    /// ```
+    ///
+    /// Ignore scale.
+    ///
+    /// This will overwrite the scale value with the default.
+    /// If you want to preserve it, use [`Self::replicate_with`] to provide
+    /// in-place deserialization.
+    ///
+    /// ```
+    /// # use bevy::state::app::StatesPlugin;
+    /// use bevy::prelude::*;
+    /// use bevy_replicon::prelude::*;
+    /// use serde::{Deserialize, Serialize};
+    ///
+    /// # let mut app = App::new();
+    /// # app.add_plugins((StatesPlugin, RepliconPlugins));
+    /// app.replicate_as::<Transform, TransformWithoutScale>();
+    ///
+    /// #[derive(Serialize, Deserialize, Clone, Copy)]
+    /// struct TransformWithoutScale {
+    ///     translation: Vec3,
+    ///     rotation: Quat,
+    /// }
+    ///
+    /// impl From<Transform> for TransformWithoutScale {
+    ///     fn from(value: Transform) -> Self {
+    ///         Self {
+    ///             translation: value.translation,
+    ///             rotation: value.rotation,
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// impl From<TransformWithoutScale> for Transform {
+    ///     fn from(value: TransformWithoutScale) -> Self {
+    ///         Self {
+    ///             translation: value.translation,
+    ///             rotation: value.rotation,
+    ///             ..Default::default()
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    fn replicate_as<C, T>(&mut self) -> &mut Self
+    where
+        C: Component<Mutability: MutWrite<C>> + Clone + Into<T> + From<T>,
+        T: Serialize + DeserializeOwned,
+    {
+        self.replicate_filtered_as::<C, T, ()>()
+    }
+
+    /// Like [`Self::replicate_as`], but uses [`ReplicationMode::Once`].
+    fn replicate_once_as<C, T>(&mut self) -> &mut Self
+    where
+        C: Component<Mutability: MutWrite<C>> + Clone + Into<T> + From<T>,
+        T: Serialize + DeserializeOwned,
+    {
+        self.replicate_once_filtered_as::<C, T, ()>()
+    }
+
     /// Like [`Self::replicate`], but lets you specify archetype filters an entity must match to replicate.
     ///
     /// Supports [`With`], [`Without`], [`Or`], and tuples of them, similar to the second generic parameter of [`Query`].
@@ -82,6 +192,24 @@ pub trait AppRuleExt {
         self.replicate_with_filtered::<_, F>((RuleFns::<C>::default(), ReplicationMode::Once))
     }
 
+    /// Like [`Self::replicate_as`], but also adds filters like [`Self::replicate_filtered`].
+    fn replicate_filtered_as<C, T, F: FilterRules>(&mut self) -> &mut Self
+    where
+        C: Component<Mutability: MutWrite<C>> + Clone + Into<T> + From<T>,
+        T: Serialize + DeserializeOwned,
+    {
+        self.replicate_with_filtered::<_, F>(RuleFns::<C>::new_as::<T>())
+    }
+
+    /// Like [`Self::replicate_filtered_as`], but for [`Self::replicate_once`].
+    fn replicate_once_filtered_as<C, T, F: FilterRules>(&mut self) -> &mut Self
+    where
+        C: Component<Mutability: MutWrite<C>> + Clone + Into<T> + From<T>,
+        T: Serialize + DeserializeOwned,
+    {
+        self.replicate_with_filtered::<_, F>((RuleFns::<C>::new_as::<T>(), ReplicationMode::Once))
+    }
+
     /**
     Defines a customizable [`ReplicationRule`].
 
@@ -116,54 +244,57 @@ pub trait AppRuleExt {
 
     # Examples
 
-    Pass [`RuleFns`] to ser/de only specific field:
+    Skip scale serialization.
+
+    Unlike with the example from [`Self::deserialize_as`], this
+    will preserve the original scale value on deserialiation.
 
     ```
     # use bevy::state::app::StatesPlugin;
     use bevy::prelude::*;
     use bevy_replicon::{
         bytes::Bytes,
-        postcard_utils,
-        shared::replication::registry::{
-            ctx::{SerializeCtx, WriteCtx},
-            rule_fns::DeserializeFn,
-        },
         prelude::*,
+        shared::replication::registry::{ctx::WriteCtx, rule_fns::DeserializeFn},
     };
+    use serde::{Deserialize, Serialize};
 
     # let mut app = App::new();
     # app.add_plugins((StatesPlugin, RepliconPlugins));
-    // We override in-place as well to apply only translation when the component is already inserted.
     app.replicate_with(
-        RuleFns::new(serialize_translation, deserialize_translation)
-            .with_in_place(deserialize_transform_in_place),
+        RuleFns::<Transform>::new_as::<TransformWithoutScale>()
+            .with_in_place(deserialize_in_place_without_scale),
     );
 
-    /// Serializes only `translation` from [`Transform`].
-    fn serialize_translation(
-        _ctx: &SerializeCtx,
-        transform: &Transform,
-        message: &mut Vec<u8>,
-    ) -> Result<()> {
-        postcard_utils::to_extend_mut(&transform.translation, message)?;
-        Ok(())
+    #[derive(Serialize, Deserialize, Clone, Copy)]
+    struct TransformWithoutScale {
+        translation: Vec3,
+        rotation: Quat,
     }
 
-    /// Deserializes `translation` and creates [`Transform`] from it.
-    ///
-    /// Called by Replicon on component insertions.
-    fn deserialize_translation(
-        _ctx: &mut WriteCtx,
-        message: &mut Bytes,
-    ) -> Result<Transform> {
-        let translation: Vec3 = postcard_utils::from_buf(message)?;
-        Ok(Transform::from_translation(translation))
+    impl From<Transform> for TransformWithoutScale {
+        fn from(value: Transform) -> Self {
+            Self {
+                translation: value.translation,
+                rotation: value.rotation,
+            }
+        }
     }
 
-    /// Applies the assigned deserialization function and assigns only translation.
+    impl From<TransformWithoutScale> for Transform {
+        fn from(value: TransformWithoutScale) -> Self {
+            Self {
+                translation: value.translation,
+                rotation: value.rotation,
+                ..Default::default()
+            }
+        }
+    }
+
+    /// Applies the assigned deserialization function and assigns only translation and rotation.
     ///
     /// Called by Replicon on component mutations.
-    fn deserialize_transform_in_place(
+    fn deserialize_in_place_without_scale(
         deserialize: DeserializeFn<Transform>,
         ctx: &mut WriteCtx,
         component: &mut Transform,
@@ -171,8 +302,10 @@ pub trait AppRuleExt {
     ) -> Result<()> {
         let transform = (deserialize)(ctx, message)?;
         component.translation = transform.translation;
+        component.rotation = transform.rotation;
         Ok(())
     }
+
     ```
 
     A rule with multiple components:
@@ -673,13 +806,15 @@ mod tests {
             .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
             .replicate::<A>()
-            .replicate_once::<B>();
+            .replicate_once::<B>()
+            .replicate_as::<A, C>()
+            .replicate_once_as::<B, D>();
 
         let rules = app
             .world_mut()
             .remove_resource::<ReplicationRules>()
             .unwrap();
-        let [rule_a, rule_b] = rules.0.try_into().unwrap();
+        let [rule_a, rule_b, rule_a_as_b, rule_b_as_d] = rules.0.try_into().unwrap();
         assert_eq!(rule_a.priority, 1);
         assert_eq!(rule_b.priority, 1);
 
@@ -694,6 +829,12 @@ mod tests {
 
         assert!(!rule_b.matches(a));
         assert!(rule_b.matches(b));
+
+        assert!(rule_a_as_b.matches(a));
+        assert!(!rule_a_as_b.matches(b));
+
+        assert!(!rule_b_as_d.matches(a));
+        assert!(rule_b_as_d.matches(b));
     }
 
     #[test]
@@ -911,15 +1052,39 @@ mod tests {
         assert!(!rule_ab_c.matches(cda));
     }
 
-    #[derive(Serialize, Deserialize, Component)]
+    #[derive(Component, Serialize, Deserialize, Clone, Copy)]
     struct A;
 
-    #[derive(Serialize, Deserialize, Component)]
+    #[derive(Component, Serialize, Deserialize, Clone, Copy)]
     struct B;
 
-    #[derive(Serialize, Deserialize, Component)]
+    #[derive(Component, Serialize, Deserialize)]
     struct C;
 
-    #[derive(Serialize, Deserialize, Component)]
+    impl From<C> for A {
+        fn from(_value: C) -> Self {
+            A
+        }
+    }
+
+    impl From<A> for C {
+        fn from(_value: A) -> Self {
+            C
+        }
+    }
+
+    #[derive(Component, Serialize, Deserialize)]
     struct D;
+
+    impl From<D> for B {
+        fn from(_value: D) -> Self {
+            B
+        }
+    }
+
+    impl From<B> for D {
+        fn from(_value: B) -> Self {
+            D
+        }
+    }
 }

--- a/src/shared/replication/rules.rs
+++ b/src/shared/replication/rules.rs
@@ -246,7 +246,7 @@ pub trait AppRuleExt {
 
     Skip scale serialization.
 
-    Unlike with the example from [`Self::deserialize_as`], this
+    Unlike with the example from [`Self::replicate_as`], this
     will preserve the original scale value on deserialiation.
 
     ```


### PR DESCRIPTION
Requires #71 to be merged first. Closes #572.

Allows converting a component into a different struct before serialization and back after deserialization. Custom ser/de functions are still useful for cases like compression, but in most situations this method is more ergonomic.