### PR TITLE
Add marker component for listen server client

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -787,7 +787,7 @@ pub mod prelude {
 
     #[cfg(feature = "server")]
     pub use super::server::{
-        AuthorizedClient, PriorityMap, ReplicatePriority, ServerPlugin, ServerSystems,
+        AuthorizedClient, HostClient, PriorityMap, ReplicatePriority, ServerPlugin, ServerSystems,
         message::ServerMessagePlugin, related_entities::SyncRelatedAppExt,
         visibility::AppVisibilityExt,
     };

--- a/src/server.rs
+++ b/src/server.rs
@@ -1001,8 +1001,9 @@ pub struct AuthorizedClient;
 
 /// Marker component for a local client running the server itself.
 ///
-/// Messaging backends are responsible for inserting this component on the server client entity.
-/// Needs to be inserted with [`NetworkId`] if the backend provides support for it.
+/// Messaging backends are responsible for inserting this component on the hosting client entity.
+/// Needs to be inserted with [NetworkId](`crate::shared::backend::connected_client::NetworkId`)
+/// if the backend provides support for it.
 ///
 /// See also [`ConnectedClient`].
 #[derive(Component, Reflect, Default, Debug)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -999,6 +999,17 @@ struct DespawnBuffer(Vec<Entity>);
 #[require(ClientTicks, ClientVisibility, PriorityMap, Updates, Mutations)]
 pub struct AuthorizedClient;
 
+/// Marker component for a local client running the server itself.
+///
+/// Messaging backends are responsible for inserting this component on the server client entity.
+/// Needs to be inserted with [`NetworkId`] if the backend provides support for it.
+///
+/// See also [`ConnectedClient`].
+#[derive(Component, Reflect, Default, Debug)]
+#[component(immutable)]
+#[reflect(Component, Default, Debug)]
+pub struct HostClient;
+
 /// Controls how often mutations are sent for a replicated entity.
 ///
 /// Applies to all authorized clients unless overridden by the client's [`PriorityMap`].


### PR DESCRIPTION
To start off, I want to define a HostClient as a local host player on a listen-server as a client entity. 
Related: #688.

I wanted to add this marker component for two reasons:

1. Client entities might be more than simple network-piece component collections. For example, a user might add metadata (username, ip, character configs, etc...) that pertains to a player. Having a hosting player also expressed as a client entity helps unifying logic.
2. Plugins building upon `bevy_replicon` can share a marker component for this usecase. This is relevant, for example, in my visibility crate, where I hope to share visibility mechanics while adding the corner case where the HostClient toggles a mesh's Visibility instead. This makes singling out a host client important.

The main trade-off is that querying for "all player clients" becomes slightly more verbose.
