### PR TITLE
Add signature from precomputed_hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Signature::from_precomputed_hash` to create a signature from a hash without hashing it again.
+- `Signature::from_hash` to create a signature from a hash without hashing it again.
 - `VisibilityFilter::LIFETIME` to control when a visibility scope is present on a client. You can now avoid removing scopes when visibility is lost or replicate their initial state even when they are not visible.
 - `ReplicationUserdata` and `UserdataReceived` to attach custom data to replication messages.
 - `DiffIndex::wrapping_cmp` to compare indices.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Signature::from_precomputed_hash` to create a signature from a hash without hashing it again.
 - `VisibilityFilter::LIFETIME` to control when a visibility scope is present on a client. You can now avoid removing scopes when visibility is lost or replicate their initial state even when they are not visible.
 - `ReplicationUserdata` and `UserdataReceived` to attach custom data to replication messages.
 - `DiffIndex::wrapping_cmp` to compare indices.

--- a/src/shared/replication/signature.rs
+++ b/src/shared/replication/signature.rs
@@ -44,17 +44,7 @@ pub struct Signature {
     client: Option<Entity>,
 
     /// Precomputed or resolved hash.
-    hash: SignatureHash,
-}
-
-#[derive(Reflect, Debug, Clone, Copy)]
-enum SignatureHash {
-    /// Needs to be calculated when added to an entity.
-    Unresolved,
-    /// Supplied by the user and should not be calculated.
-    Precomputed(u64),
-    /// Calculated when added to an entity.
-    Resolved(u64),
+    hash: Option<u64>,
 }
 
 impl Signature {
@@ -142,7 +132,7 @@ impl Signature {
             salt: None,
             fns: &[hash::<C>],
             client: None,
-            hash: SignatureHash::Unresolved,
+            hash: None,
         }
     }
 
@@ -235,7 +225,7 @@ impl Signature {
             salt: None,
             fns: S::HASH_FNS,
             client: None,
-            hash: SignatureHash::Unresolved,
+            hash: None,
         }
     }
 
@@ -249,7 +239,7 @@ impl Signature {
             salt: None,
             fns: &[],
             client: None,
-            hash: SignatureHash::Precomputed(hash),
+            hash: Some(hash),
         }
     }
 
@@ -265,7 +255,7 @@ impl Signature {
         value.hash(&mut hasher);
 
         self.salt = Some(hasher.finish());
-        self.hash = SignatureHash::Unresolved;
+        self.hash = None;
         self
     }
 
@@ -284,15 +274,15 @@ impl Signature {
 
     pub(crate) fn hash(&self) -> u64 {
         match self.hash {
-            SignatureHash::Precomputed(hash) | SignatureHash::Resolved(hash) => hash,
-            SignatureHash::Unresolved => {
+            Some(hash) => hash,
+            None => {
                 unreachable!("signature hash should be resolved on insertion")
             }
         }
     }
 
     fn eval<'a>(&self, entity: impl Into<EntityRef<'a>>) -> u64 {
-        if let SignatureHash::Precomputed(hash) = self.hash {
+        if let Some(hash) = self.hash {
             return hash;
         }
 
@@ -324,7 +314,7 @@ impl<T: Hash> From<T> for Signature {
             salt: Some(hasher.finish()),
             fns: &[],
             client: None,
-            hash: SignatureHash::Unresolved,
+            hash: None,
         }
     }
 }
@@ -336,7 +326,7 @@ fn register_hash(mut world: DeferredWorld, ctx: HookContext) {
 
     // Re-borrow due to borrow-checker.
     let mut signature = entity.get_mut::<Signature>().unwrap();
-    signature.hash = SignatureHash::Resolved(hash);
+    signature.hash = Some(hash);
 
     if let Some(mut map) = world.get_resource_mut::<SignatureMap>() {
         map.insert(ctx.entity, hash);
@@ -451,22 +441,6 @@ mod tests {
             world.entity(entity).get::<Signature>().unwrap().hash(),
             HASH
         );
-    }
-
-    #[test]
-    fn resolved_hash_is_recomputed() {
-        let mut world = World::new();
-        let entity1 = world.spawn(C(true)).id();
-        world.entity_mut(entity1).insert(Signature::of::<C>());
-
-        let resolved_signature = *world.entity(entity1).get::<Signature>().unwrap();
-        let hash1 = resolved_signature.hash();
-
-        let entity2 = world.spawn(C(false)).id();
-        world.entity_mut(entity2).insert(resolved_signature);
-        let hash2 = world.entity(entity2).get::<Signature>().unwrap().hash();
-
-        assert_ne!(hash1, hash2);
     }
 
     #[test]

--- a/src/shared/replication/signature.rs
+++ b/src/shared/replication/signature.rs
@@ -19,19 +19,23 @@ use xxhash_rust::xxh3::Xxh3Default;
 /// If there is no mapping, it spawns a new entity and creates a new mapping to it.
 ///
 /// To re-use a previously spawned entity on the client, insert this component on both
-/// server and client. On insertion it will calculate a hash and on replication client
-/// will try to match. If the hash matches, the replication will continue to previously
-/// spawned entity.
+/// server and client. On insertion it will calculate a hash or use a precomputed one,
+/// and on replication client will try to match. If the hash matches, the replication
+/// will continue to previously spawned entity.
 ///
-/// The hash can be calculated from components on the entity, a user-defined struct, or both.
-/// The user needs to use something that is unique for each entity, but identical for the
-/// same entity on both client and server.
+/// The hash can be calculated from components on the entity, a user-defined struct, or both,
+/// or it can be provided directly via [`Self::from_precomputed_hash`]. The user needs to use
+/// something that is unique for each entity, but identical for the same entity on both client
+/// and server.
 ///
 /// Signatures can also be relevant only to a specific client. In this case, the signature
 /// will be sent only to that client.
 #[derive(Component, Reflect, Debug, Clone, Copy)]
 #[component(on_add = register_hash, on_remove = unregister_hash)]
 pub struct Signature {
+    /// Hash supplied directly by the user.
+    precomputed_hash: Option<u64>,
+
     /// User-defined value added to the hash.
     salt: Option<u64>,
 
@@ -130,6 +134,7 @@ impl Signature {
     #[must_use]
     pub fn of<C: Component + Hash>() -> Self {
         Self {
+            precomputed_hash: None,
             salt: None,
             fns: &[hash::<C>],
             client: None,
@@ -223,8 +228,24 @@ impl Signature {
     #[must_use]
     pub fn of_n<S: SignatureComponents>() -> Self {
         Self {
+            precomputed_hash: None,
             salt: None,
             fns: S::HASH_FNS,
+            client: None,
+            hash: 0,
+        }
+    }
+
+    /// Creates a new instance with a precomputed hash.
+    ///
+    /// The provided hash is used directly without hashing any values or components.
+    /// Calling [`Self::with_salt`] afterward replaces it with a calculated hash.
+    #[must_use]
+    pub fn from_precomputed_hash(hash: u64) -> Self {
+        Self {
+            precomputed_hash: Some(hash),
+            salt: None,
+            fns: &[],
             client: None,
             hash: 0,
         }
@@ -241,6 +262,7 @@ impl Signature {
         let mut hasher = DeterministicHasher::<Xxh3Default>::default();
         value.hash(&mut hasher);
 
+        self.precomputed_hash = None;
         self.salt = Some(hasher.finish());
         self
     }
@@ -263,6 +285,10 @@ impl Signature {
     }
 
     fn eval<'a>(&self, entity: impl Into<EntityRef<'a>>) -> u64 {
+        if let Some(hash) = self.precomputed_hash {
+            return hash;
+        }
+
         let mut hasher = DeterministicHasher::<Xxh3Default>::default();
         if let Some(salt) = self.salt {
             salt.hash(&mut hasher);
@@ -288,6 +314,7 @@ impl<T: Hash> From<T> for Signature {
         value.hash(&mut hasher);
 
         Self {
+            precomputed_hash: None,
             salt: Some(hasher.finish()),
             fns: &[],
             client: None,
@@ -405,6 +432,19 @@ mod tests {
     fn no_panic_without_map() {
         let mut world = World::new();
         world.spawn(Signature::from(0)).despawn();
+    }
+
+    #[test]
+    fn precomputed_hash() {
+        const HASH: u64 = 12;
+
+        let mut world = World::new();
+        let entity = world.spawn(Signature::from_precomputed_hash(HASH)).id();
+
+        assert_eq!(
+            world.entity(entity).get::<Signature>().unwrap().hash(),
+            HASH
+        );
     }
 
     #[test]

--- a/src/shared/replication/signature.rs
+++ b/src/shared/replication/signature.rs
@@ -44,7 +44,9 @@ pub struct Signature {
     /// Relevant client.
     client: Option<Entity>,
 
-    /// Precomputed or resolved hash.
+    /// Resulting hash.
+    ///
+    /// Calculated when added to an entity or set directly via [`Self::from_hash`].
     hash: Option<u64>,
 }
 

--- a/src/shared/replication/signature.rs
+++ b/src/shared/replication/signature.rs
@@ -19,14 +19,15 @@ use xxhash_rust::xxh3::Xxh3Default;
 /// If there is no mapping, it spawns a new entity and creates a new mapping to it.
 ///
 /// To re-use a previously spawned entity on the client, insert this component on both
-/// server and client. On insertion it will calculate a hash or use a precomputed one,
-/// and on replication client will try to match. If the hash matches, the replication
-/// will continue to previously spawned entity.
+/// server and client. On insertion it will calculate a hash and on replication client
+/// will try to match. If the hash matches, the replication will continue to previously
+/// spawned entity.
 ///
-/// The hash can be calculated from components on the entity, a user-defined struct, or both,
-/// or it can be provided directly via [`Self::from_hash`]. The user needs to use
-/// something that is unique for each entity, but identical for the same entity on both client
-/// and server.
+/// The hash can be calculated from components on the entity, a user-defined struct, or both.
+/// The user needs to use something that is unique for each entity, but identical for the
+/// same entity on both client and server.
+///
+/// You can also provide the hash yourself via [`Self::from_hash`].
 ///
 /// Signatures can also be relevant only to a specific client. In this case, the signature
 /// will be sent only to that client.

--- a/src/shared/replication/signature.rs
+++ b/src/shared/replication/signature.rs
@@ -24,7 +24,7 @@ use xxhash_rust::xxh3::Xxh3Default;
 /// will continue to previously spawned entity.
 ///
 /// The hash can be calculated from components on the entity, a user-defined struct, or both,
-/// or it can be provided directly via [`Self::from_precomputed_hash`]. The user needs to use
+/// or it can be provided directly via [`Self::from_hash`]. The user needs to use
 /// something that is unique for each entity, but identical for the same entity on both client
 /// and server.
 ///
@@ -234,7 +234,7 @@ impl Signature {
     /// The provided hash is used directly without hashing any values or components.
     /// Calling [`Self::with_salt`] afterward replaces it with a calculated hash.
     #[must_use]
-    pub fn from_precomputed_hash(hash: u64) -> Self {
+    pub fn from_hash(hash: u64) -> Self {
         Self {
             salt: None,
             fns: &[],
@@ -431,11 +431,11 @@ mod tests {
     }
 
     #[test]
-    fn precomputed_hash() {
+    fn from_hash() {
         const HASH: u64 = 12;
 
         let mut world = World::new();
-        let entity = world.spawn(Signature::from_precomputed_hash(HASH)).id();
+        let entity = world.spawn(Signature::from_hash(HASH)).id();
 
         assert_eq!(
             world.entity(entity).get::<Signature>().unwrap().hash(),

--- a/src/shared/replication/signature.rs
+++ b/src/shared/replication/signature.rs
@@ -276,12 +276,8 @@ impl Signature {
     }
 
     pub(crate) fn hash(&self) -> u64 {
-        match self.hash {
-            Some(hash) => hash,
-            None => {
-                unreachable!("signature hash should be resolved on insertion")
-            }
-        }
+        self.hash
+            .expect("signature hash is only available after insertion into an entity")
     }
 
     fn eval<'a>(&self, entity: impl Into<EntityRef<'a>>) -> u64 {

--- a/src/shared/replication/signature.rs
+++ b/src/shared/replication/signature.rs
@@ -33,9 +33,6 @@ use xxhash_rust::xxh3::Xxh3Default;
 #[derive(Component, Reflect, Debug, Clone, Copy)]
 #[component(on_add = register_hash, on_remove = unregister_hash)]
 pub struct Signature {
-    /// Hash supplied directly by the user.
-    precomputed_hash: Option<u64>,
-
     /// User-defined value added to the hash.
     salt: Option<u64>,
 
@@ -46,10 +43,18 @@ pub struct Signature {
     /// Relevant client.
     client: Option<Entity>,
 
-    /// Resulting hash.
-    ///
+    /// Precomputed or resolved hash.
+    hash: SignatureHash,
+}
+
+#[derive(Reflect, Debug, Clone, Copy)]
+enum SignatureHash {
+    /// Needs to be calculated when added to an entity.
+    Unresolved,
+    /// Supplied by the user and should not be calculated.
+    Precomputed(u64),
     /// Calculated when added to an entity.
-    hash: u64,
+    Resolved(u64),
 }
 
 impl Signature {
@@ -134,11 +139,10 @@ impl Signature {
     #[must_use]
     pub fn of<C: Component + Hash>() -> Self {
         Self {
-            precomputed_hash: None,
             salt: None,
             fns: &[hash::<C>],
             client: None,
-            hash: 0,
+            hash: SignatureHash::Unresolved,
         }
     }
 
@@ -228,11 +232,10 @@ impl Signature {
     #[must_use]
     pub fn of_n<S: SignatureComponents>() -> Self {
         Self {
-            precomputed_hash: None,
             salt: None,
             fns: S::HASH_FNS,
             client: None,
-            hash: 0,
+            hash: SignatureHash::Unresolved,
         }
     }
 
@@ -243,11 +246,10 @@ impl Signature {
     #[must_use]
     pub fn from_precomputed_hash(hash: u64) -> Self {
         Self {
-            precomputed_hash: Some(hash),
             salt: None,
             fns: &[],
             client: None,
-            hash: 0,
+            hash: SignatureHash::Precomputed(hash),
         }
     }
 
@@ -262,8 +264,8 @@ impl Signature {
         let mut hasher = DeterministicHasher::<Xxh3Default>::default();
         value.hash(&mut hasher);
 
-        self.precomputed_hash = None;
         self.salt = Some(hasher.finish());
+        self.hash = SignatureHash::Unresolved;
         self
     }
 
@@ -281,11 +283,16 @@ impl Signature {
     }
 
     pub(crate) fn hash(&self) -> u64 {
-        self.hash
+        match self.hash {
+            SignatureHash::Precomputed(hash) | SignatureHash::Resolved(hash) => hash,
+            SignatureHash::Unresolved => {
+                unreachable!("signature hash should be resolved on insertion")
+            }
+        }
     }
 
     fn eval<'a>(&self, entity: impl Into<EntityRef<'a>>) -> u64 {
-        if let Some(hash) = self.precomputed_hash {
+        if let SignatureHash::Precomputed(hash) = self.hash {
             return hash;
         }
 
@@ -314,11 +321,10 @@ impl<T: Hash> From<T> for Signature {
         value.hash(&mut hasher);
 
         Self {
-            precomputed_hash: None,
             salt: Some(hasher.finish()),
             fns: &[],
             client: None,
-            hash: 0,
+            hash: SignatureHash::Unresolved,
         }
     }
 }
@@ -330,7 +336,7 @@ fn register_hash(mut world: DeferredWorld, ctx: HookContext) {
 
     // Re-borrow due to borrow-checker.
     let mut signature = entity.get_mut::<Signature>().unwrap();
-    signature.hash = hash;
+    signature.hash = SignatureHash::Resolved(hash);
 
     if let Some(mut map) = world.get_resource_mut::<SignatureMap>() {
         map.insert(ctx.entity, hash);
@@ -445,6 +451,22 @@ mod tests {
             world.entity(entity).get::<Signature>().unwrap().hash(),
             HASH
         );
+    }
+
+    #[test]
+    fn resolved_hash_is_recomputed() {
+        let mut world = World::new();
+        let entity1 = world.spawn(C(true)).id();
+        world.entity_mut(entity1).insert(Signature::of::<C>());
+
+        let resolved_signature = *world.entity(entity1).get::<Signature>().unwrap();
+        let hash1 = resolved_signature.hash();
+
+        let entity2 = world.spawn(C(false)).id();
+        world.entity_mut(entity2).insert(resolved_signature);
+        let hash2 = world.entity(entity2).get::<Signature>().unwrap().hash();
+
+        assert_ne!(hash1, hash2);
     }
 
     #[test]


### PR DESCRIPTION
Fixes https://github.com/simgine/bevy_replicon/issues/737

Impl is a bit awkward as i had to add a new field. Maybe i could just set `hash` directly, and have a `precomputed: bool` instead?