### PR TITLE
Add filter bit getter to FilterRegistry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `FilterRegistry::get_bit` to retrieve a bit by type from the filter registry (can also be useful for checking if a `VisibilityFilter` has been registered).
+
 ## [0.42.1] - 2026-08-09
 
 ### Fixed

--- a/src/server/visibility/registry.rs
+++ b/src/server/visibility/registry.rs
@@ -37,6 +37,11 @@ impl FilterRegistry {
         }
     }
 
+    /// Returns a filter bit for a registered visibility filter.
+    pub fn get_bit<F: VisibilityFilter>(&self) -> Option<FilterBit> {
+        self.bits.get_type::<F>().copied()
+    }
+
     /// Registers a new visibility scope and returns the [`FilterBit`] assigned to it.
     ///
     /// The returned bit should be managed manually via


### PR DESCRIPTION
Found it useful for validating that I registered a generic visibility filter in a component insertion hook (I often find myself forgetting to register new types used in such generic filters), for example:

```rust
#[derive(Component, Default)]
#[component(immutable, storage = "SparseSet", on_add = assert_registered::<Self>)]
pub struct PauseReplication<T: Component>
where
    <T as bevy_ecs::component::Component>::Mutability:
        bevy_replicon::shared::replication::registry::receive_fns::MutWrite<T>,
{
    _phantom: PhantomData<T>,
}

impl<T: Component> VisibilityFilter for PauseReplication<T>
where
    <T as bevy_ecs::component::Component>::Mutability:
        bevy_replicon::shared::replication::registry::receive_fns::MutWrite<T>,
{
    type ClientComponent = Self;
    type Scope = SingleComponent<T>;
    const LIFETIME: ScopeLifetime = ScopeLifetime::AfterFirstVisibility;

    fn is_visible(&self, _client: Entity, _component: Option<&Self::ClientComponent>) -> bool {
        false
    }
}

fn assert_registered<T: VisibilityFilter>(world: DeferredWorld, _context: HookContext) {
    debug_assert_ne!(
        world.resource::<FilterRegistry>().get_bit::<T>(),
        None,
        "{} visibility filter is not registered",
        std::any::type_name::<T>()
    );
}
```

If you agree with the use-case but prefer a slightly other interface for it, let me know or feel free to push directly into my PR.
Thanks!