### PR TITLE
Apply marker components instantly if they are part of the Update message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- If the server sends an entity Update that contains a Marker component, the Marker will be applied when the Update message is received on the client. (Previously, Marker components were only 
+  applied if they were present on the receiver entity when the Update message was received)
+
 ## [0.42.2] - 2026-08-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- If the server sends an entity Update that contains a Marker component, the Marker will be applied when the Update message is received on the client. (Previously, Marker components were only 
-  applied if they were present on the receiver entity when the Update message was received)
+### Changed
+
+- Marker components are now part of the protocol (should be registered on both, client and server) and taken into account if they're is included as a part of the entity update.
 
 ## [0.42.2] - 2026-08-14
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -588,17 +588,19 @@ fn apply_changes(
     confirm_tick(&mut client_entity, params.replicated, message_tick);
 
     let mut data = message.split_to(data_size);
-    // The server sorts incoming markers before all other components. Once a non-marker is read,
-    // no later component in this entity update needs a marker lookup.
-    let mut reading_markers = true;
+    // The server sorts incoming markers from highest to lowest priority before all other
+    // components. Only the first component needs to be checked because, if it's a marker,
+    // lower-priority markers can't affect receive-function selection.
+    let mut first_component = true;
     let len = apply_array(ArrayKind::Dynamic, &mut data, |data| {
         let spawner = BufferedSpawner::new(entity_allocator, params.entity_buffer);
         let fns_id = postcard_utils::from_buf(data)?;
         let (_, component_id, fns) = params.registry.get(fns_id);
-        if reading_markers {
-            reading_markers = params
+        if first_component {
+            params
                 .entity_markers
                 .include(params.receive_markers, component_id);
+            first_component = false;
         }
         let mut ctx = WriteCtx {
             entity: client_entity.id(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -588,10 +588,18 @@ fn apply_changes(
     confirm_tick(&mut client_entity, params.replicated, message_tick);
 
     let mut data = message.split_to(data_size);
+    // The server sorts incoming markers before all other components. Once a non-marker is read,
+    // no later component in this entity update needs a marker lookup.
+    let mut reading_markers = true;
     let len = apply_array(ArrayKind::Dynamic, &mut data, |data| {
         let spawner = BufferedSpawner::new(entity_allocator, params.entity_buffer);
         let fns_id = postcard_utils::from_buf(data)?;
         let (_, component_id, fns) = params.registry.get(fns_id);
+        if reading_markers {
+            reading_markers = params
+                .entity_markers
+                .include(params.receive_markers, component_id);
+        }
         let mut ctx = WriteCtx {
             entity: client_entity.id(),
             component_id,

--- a/src/server.rs
+++ b/src/server.rs
@@ -38,6 +38,7 @@ use crate::{
         message::server_message::message_buffer::MessageBuffer,
         replication::{
             client_ticks::{ClientTicks, EntityTicks},
+            receive_markers::ReceiveMarkers,
             registry::{
                 ComponentIndex, ReplicationRegistry, component_mask::ComponentMask,
                 ctx::SerializeCtx,
@@ -305,6 +306,7 @@ fn buffer_removals(
     mut replicated_archetypes: ResMut<ReplicatedArchetypes>,
     rules: Res<ReplicationRules>,
     registry: Option<Res<ReplicationRegistry>>,
+    receive_markers: Option<Res<ReceiveMarkers>>,
     mut removals: ResMut<RemovalBuffer>,
 ) {
     if *state != ServerState::Running {
@@ -318,11 +320,13 @@ fn buffer_removals(
     }
 
     // Observers can't use run conditions. We return early on the client, but system parameters
-    // are validated before the observer runs. Because of this, the registry may not be present
-    // in the world during replication receive, so it needs to be optional.
+    // are validated before the observer runs. Because of this, resources removed during
+    // replication receive may not be present, so they need to be optional.
     let registry = registry.expect("registry should always exist on the server");
+    let receive_markers =
+        receive_markers.expect("receive markers should always exist on the server");
 
-    replicated_archetypes.update(archetypes, &rules);
+    replicated_archetypes.update(archetypes, &rules, &receive_markers);
     let location = entities.get_spawned(remove.entity).unwrap();
     let Some(archetype) = replicated_archetypes.get(location.archetype_id) else {
         // `Replicated` component is missing.
@@ -525,6 +529,7 @@ fn collect_removals(
     entities: &Entities,
     removal_buffer: Res<RemovalBuffer>,
     rules: Res<ReplicationRules>,
+    receive_markers: Res<ReceiveMarkers>,
     registry: Res<ReplicationRegistry>,
     filter_registry: Res<FilterRegistry>,
     mut replicated_archetypes: ResMut<ReplicatedArchetypes>,
@@ -537,7 +542,7 @@ fn collect_removals(
         &mut ClientVisibility,
     )>,
 ) -> Result<()> {
-    replicated_archetypes.update(archetypes, &rules);
+    replicated_archetypes.update(archetypes, &rules, &receive_markers);
 
     for (&entity, remove_ids) in removal_buffer.iter() {
         let mut entity_range = None;
@@ -674,6 +679,7 @@ fn collect_changes(
     type_registry: Res<AppTypeRegistry>,
     related_entities: Res<RelatedEntities>,
     rules: Res<ReplicationRules>,
+    receive_markers: Res<ReceiveMarkers>,
     mut replication_storage: ResMut<ReplicationStorage>,
     mut replicated_archetypes: ResMut<ReplicatedArchetypes>,
     mut serialized: ResMut<SerializedData>,
@@ -687,7 +693,7 @@ fn collect_changes(
         &mut ClientVisibility,
     )>,
 ) -> Result<()> {
-    replicated_archetypes.update(archetypes, &rules);
+    replicated_archetypes.update(archetypes, &rules, &receive_markers);
 
     for replicated_archetype in replicated_archetypes.iter() {
         // SAFETY: all IDs from replicated archetypes obtained from real archetypes.

--- a/src/server/replicated_archetypes.rs
+++ b/src/server/replicated_archetypes.rs
@@ -137,7 +137,8 @@ mod tests {
     fn empty() {
         let mut app = App::new();
         app.init_resource::<ReplicatedArchetypes>()
-            .init_resource::<ReplicationRules>();
+            .init_resource::<ReplicationRules>()
+            .init_resource::<ReceiveMarkers>();
 
         app.world_mut().spawn_empty();
         update_archetypes(&mut app);
@@ -150,7 +151,8 @@ mod tests {
     fn no_components() {
         let mut app = App::new();
         app.init_resource::<ReplicatedArchetypes>()
-            .init_resource::<ReplicationRules>();
+            .init_resource::<ReplicationRules>()
+            .init_resource::<ReceiveMarkers>();
 
         app.world_mut().spawn(Replicated);
         update_archetypes(&mut app);
@@ -168,6 +170,7 @@ mod tests {
             .init_resource::<ReplicationRules>()
             .init_resource::<ProtocolHasher>()
             .init_resource::<ReplicationRegistry>()
+            .init_resource::<ReceiveMarkers>()
             .replicate::<A>();
 
         app.world_mut().spawn((Replicated, A));
@@ -186,6 +189,7 @@ mod tests {
             .init_resource::<ReplicationRules>()
             .init_resource::<ProtocolHasher>()
             .init_resource::<ReplicationRegistry>()
+            .init_resource::<ReceiveMarkers>()
             .replicate_bundle::<(A, B)>();
 
         app.world_mut().spawn((Replicated, A, B));
@@ -204,6 +208,7 @@ mod tests {
             .init_resource::<ReplicationRules>()
             .init_resource::<ProtocolHasher>()
             .init_resource::<ReplicationRegistry>()
+            .init_resource::<ReceiveMarkers>()
             .replicate_bundle::<(A, B)>();
 
         app.world_mut().spawn((Replicated, A));
@@ -222,6 +227,7 @@ mod tests {
             .init_resource::<ReplicationRules>()
             .init_resource::<ProtocolHasher>()
             .init_resource::<ReplicationRegistry>()
+            .init_resource::<ReceiveMarkers>()
             .replicate::<A>()
             .replicate_bundle::<(A, B)>();
 
@@ -241,6 +247,7 @@ mod tests {
             .init_resource::<ReplicationRules>()
             .init_resource::<ProtocolHasher>()
             .init_resource::<ReplicationRegistry>()
+            .init_resource::<ReceiveMarkers>()
             .replicate::<A>()
             .replicate::<B>()
             .replicate_bundle::<(A, B)>();
@@ -261,6 +268,7 @@ mod tests {
             .init_resource::<ReplicationRules>()
             .init_resource::<ProtocolHasher>()
             .init_resource::<ReplicationRegistry>()
+            .init_resource::<ReceiveMarkers>()
             .replicate_bundle::<(A, B)>()
             .replicate_bundle::<(A, C)>();
 
@@ -274,7 +282,6 @@ mod tests {
     }
 
     fn update_archetypes(app: &mut App) {
-        app.init_resource::<ReceiveMarkers>();
         app.world_mut()
             .resource_scope(|world, mut archetypes: Mut<ReplicatedArchetypes>| {
                 let rules = world.resource::<ReplicationRules>();

--- a/src/server/replicated_archetypes.rs
+++ b/src/server/replicated_archetypes.rs
@@ -12,7 +12,10 @@ use log::trace;
 
 use crate::{
     prelude::*,
-    shared::replication::rules::{ReplicationRules, component::ComponentRule},
+    shared::replication::{
+        receive_markers::ReceiveMarkers,
+        rules::{ReplicationRules, component::ComponentRule},
+    },
 };
 
 #[derive(Resource)]
@@ -31,7 +34,12 @@ pub(super) struct ReplicatedArchetypes {
 }
 
 impl ReplicatedArchetypes {
-    pub(super) fn update(&mut self, archetypes: &Archetypes, rules: &ReplicationRules) {
+    pub(super) fn update(
+        &mut self,
+        archetypes: &Archetypes,
+        rules: &ReplicationRules,
+        receive_markers: &ReceiveMarkers,
+    ) {
         let old_generation = mem::replace(&mut self.generation, archetypes.generation());
 
         for archetype in archetypes[old_generation..]
@@ -58,6 +66,12 @@ impl ReplicatedArchetypes {
                     replicated_archetype.components.push((component, storage));
                 }
             }
+
+            // Incoming receive markers need to be processed before other components so they can
+            // affect which receive functions are selected for the rest of the entity update.
+            replicated_archetype.components.sort_by_key(|(rule, _)| {
+                receive_markers.marker_index(rule.id).unwrap_or(usize::MAX)
+            });
 
             self.ids_map.insert(archetype.id(), self.list.len());
             self.list.push(replicated_archetype);
@@ -260,10 +274,12 @@ mod tests {
     }
 
     fn update_archetypes(app: &mut App) {
+        app.init_resource::<ReceiveMarkers>();
         app.world_mut()
             .resource_scope(|world, mut archetypes: Mut<ReplicatedArchetypes>| {
                 let rules = world.resource::<ReplicationRules>();
-                archetypes.update(world.archetypes(), rules);
+                let receive_markers = world.resource::<ReceiveMarkers>();
+                archetypes.update(world.archetypes(), rules, receive_markers);
             });
     }
 

--- a/src/shared/protocol.rs
+++ b/src/shared/protocol.rs
@@ -68,6 +68,17 @@ impl ProtocolHasher {
         self.hash::<B>(ProtocolPart::ReplicateBundle);
     }
 
+    pub(crate) fn register_marker<M>(&mut self, priority: usize, need_history: bool) {
+        debug!(
+            "registering receive marker `{}` with priority {priority} and need_history {need_history}",
+            ShortName::of::<M>()
+        );
+        self.hash::<M>(ProtocolPart::ReceiveMarker {
+            priority: priority as u64,
+            need_history,
+        });
+    }
+
     pub(crate) fn add_client_message<E>(&mut self) {
         debug!("adding client message `{}`", ShortName::of::<E>());
         self.hash::<E>(ProtocolPart::ClientMessage);
@@ -139,6 +150,7 @@ enum ProtocolPart {
     IndependentEvent,
     SharedMessage,
     SharedEvent,
+    ReceiveMarker { priority: u64, need_history: bool },
 }
 
 /// Hash of all registered events and replication rules.
@@ -193,6 +205,28 @@ mod tests {
 
         let mut hasher2 = ProtocolHasher::default();
         hasher2.replicate::<StructA>(0);
+
+        assert_ne!(hasher1.finish(), hasher2.finish());
+    }
+
+    #[test]
+    fn wrong_marker_config() {
+        let mut hasher1 = ProtocolHasher::default();
+        hasher1.register_marker::<StructA>(0, false);
+
+        let mut hasher2 = ProtocolHasher::default();
+        hasher2.register_marker::<StructA>(1, false);
+
+        assert_ne!(hasher1.finish(), hasher2.finish());
+    }
+
+    #[test]
+    fn wrong_marker_type() {
+        let mut hasher1 = ProtocolHasher::default();
+        hasher1.register_marker::<StructA>(0, false);
+
+        let mut hasher2 = ProtocolHasher::default();
+        hasher2.register_marker::<StructB>(0, false);
 
         assert_ne!(hasher1.finish(), hasher2.finish());
     }

--- a/src/shared/replication/receive_markers.rs
+++ b/src/shared/replication/receive_markers.rs
@@ -275,6 +275,9 @@ impl ReceiveMarkers {
     }
 
     /// Returns the marker's position in priority order.
+    ///
+    /// The number of markers is expected to be small, so linear search through an array
+    /// should be faster than using a HashMap.
     pub(crate) fn marker_index(&self, component_id: ComponentId) -> Option<usize> {
         self.0
             .iter()

--- a/src/shared/replication/receive_markers.rs
+++ b/src/shared/replication/receive_markers.rs
@@ -3,6 +3,8 @@ use core::cmp::Reverse;
 use bevy::{ecs::component::ComponentId, prelude::*};
 use log::debug;
 
+use crate::shared::protocol::ProtocolHasher;
+
 use super::registry::{
     ReplicationRegistry,
     receive_fns::{MutWrite, RemoveFn, WriteFn},
@@ -20,6 +22,9 @@ pub trait AppMarkerExt {
     /// Can be used to override how this component or other components will be written or removed
     /// based on marker-component presence.
     /// For details see [`Self::set_marker_fns`].
+    ///
+    /// Marker registration is part of the protocol and should be performed in the same order
+    /// on the client and server.
     ///
     /// This function registers markers with default [`MarkerConfig`].
     /// See also [`Self::register_marker_with`].
@@ -183,6 +188,9 @@ impl AppMarkerExt for App {
 
     fn register_marker_with<M: Component>(&mut self, config: MarkerConfig) -> &mut Self {
         debug!("registering marker `{}`", ShortName::of::<M>());
+        self.world_mut()
+            .resource_mut::<ProtocolHasher>()
+            .register_marker::<M>(config.priority, config.need_history);
         let component_id = self.world_mut().register_component::<M>();
         let mut receive_markers = self.world_mut().resource_mut::<ReceiveMarkers>();
         let marker_id = receive_markers.insert(ReceiveMarker {
@@ -260,12 +268,17 @@ impl ReceiveMarkers {
     /// Returns marker ID from its component ID.
     fn marker_id(&self, component_id: ComponentId) -> ReceiveMarkerIndex {
         let index = self
-            .0
-            .iter()
-            .position(|marker| marker.component_id == component_id)
+            .marker_index(component_id)
             .unwrap_or_else(|| panic!("marker {component_id:?} wasn't registered"));
 
         ReceiveMarkerIndex(index)
+    }
+
+    /// Returns the marker's position in priority order.
+    pub(crate) fn marker_index(&self, component_id: ComponentId) -> Option<usize> {
+        self.0
+            .iter()
+            .position(|marker| marker.component_id == component_id)
     }
 
     pub(super) fn iter_require_history(&self) -> impl Iterator<Item = bool> + '_ {
@@ -331,6 +344,22 @@ impl EntityMarkers {
         }
     }
 
+    /// Includes a marker component that is about to be inserted on the entity.
+    ///
+    /// Returns `true` if `component_id` belongs to a registered marker.
+    pub(crate) fn include(&mut self, markers: &ReceiveMarkers, component_id: ComponentId) -> bool {
+        let Some(index) = markers.marker_index(component_id) else {
+            return false;
+        };
+
+        self.markers[index] = true;
+        if markers.0[index].config.need_history {
+            self.need_history = true;
+        }
+
+        true
+    }
+
     /// Returns a slice of which markers are present on an entity.
     ///
     /// Indices corresponds markers in to [`ReceiveMarkers`].
@@ -384,6 +413,7 @@ mod tests {
         let mut app = App::new();
         app.init_resource::<ReceiveMarkers>()
             .init_resource::<ReplicationRegistry>()
+            .init_resource::<ProtocolHasher>()
             .register_marker::<MarkerA>()
             .register_marker_with::<MarkerB>(MarkerConfig {
                 priority: 2,
@@ -402,6 +432,34 @@ mod tests {
             .map(|marker| marker.config.priority)
             .collect();
         assert_eq!(priorities, [2, 1, 0, 0]);
+    }
+
+    #[test]
+    fn include() {
+        let mut app = App::new();
+        app.init_resource::<ReceiveMarkers>()
+            .init_resource::<ReplicationRegistry>()
+            .init_resource::<ProtocolHasher>()
+            .register_marker_with::<Marker>(MarkerConfig {
+                need_history: true,
+                ..Default::default()
+            });
+
+        let marker_id = app.world_mut().register_component::<Marker>();
+        let component_id = app.world_mut().register_component::<TestComponent>();
+        let markers = app.world().resource::<ReceiveMarkers>();
+        let mut entity_markers = EntityMarkers {
+            markers: vec![false; markers.0.len()],
+            need_history: false,
+        };
+
+        assert!(!entity_markers.include(markers, component_id));
+        assert_eq!(entity_markers.markers(), [false]);
+        assert!(!entity_markers.need_history());
+
+        assert!(entity_markers.include(markers, marker_id));
+        assert_eq!(entity_markers.markers(), [true]);
+        assert!(entity_markers.need_history());
     }
 
     #[derive(Component)]

--- a/src/shared/replication/receive_markers.rs
+++ b/src/shared/replication/receive_markers.rs
@@ -3,12 +3,11 @@ use core::cmp::Reverse;
 use bevy::{ecs::component::ComponentId, prelude::*};
 use log::debug;
 
-use crate::shared::protocol::ProtocolHasher;
-
 use super::registry::{
     ReplicationRegistry,
     receive_fns::{MutWrite, RemoveFn, WriteFn},
 };
+use crate::shared::protocol::ProtocolHasher;
 
 /// Marker-based replication receive functions for [`App`].
 ///

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -439,6 +439,43 @@ fn marker() {
 }
 
 #[test]
+fn marker_from_same_update() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .register_marker::<ReplaceMarker>()
+        // Register the regular component first to verify that receive markers are reordered.
+        .replicate::<Original>()
+        .set_marker_fns::<ReplaceMarker, _>(replace, receive_fns::default_remove::<Replaced>)
+        .replicate::<ReplaceMarker>()
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+    server_app
+        .world_mut()
+        .spawn((Replicated, Original, ReplaceMarker));
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let entity = client_app
+        .world_mut()
+        .query_filtered::<EntityRef, With<Remote>>()
+        .single(client_app.world())
+        .unwrap();
+    assert!(entity.contains::<ReplaceMarker>());
+    assert!(entity.contains::<Replaced>());
+    assert!(!entity.contains::<Original>());
+}
+
+#[test]
 fn group() {
     let mut server_app = App::new();
     let mut client_app = App::new();
@@ -913,7 +950,7 @@ struct A;
 #[derive(Component, Deserialize, Serialize)]
 struct B;
 
-#[derive(Component)]
+#[derive(Component, Deserialize, Serialize)]
 struct ReplaceMarker;
 
 #[derive(Component, Deserialize, Serialize)]
@@ -1017,7 +1054,7 @@ impl VisibilityFilter for AllExceptVisibility {
     }
 }
 
-/// Deserializes [`OriginalComponent`], but ignores it and inserts [`ReplacedComponent`].
+/// Deserializes [`Original`], but ignores it and inserts [`Replaced`].
 fn replace(
     ctx: &mut WriteCtx,
     rule_fns: &RuleFns<Original>,


### PR DESCRIPTION
Fixes https://github.com/simgine/bevy_replicon/issues/742

This change makes sure that if the server includes a marker component M on an entity, then the replication rules for marker M will be run on the receiver.

Idea:
- we sort the components on the replicated archetypes so that marker components are ordered first (with highest priority first).
- on the client, when we receive an Update message, we check if the first component is a marker. If it is, we can stop there (since it is the highest priority marker). If it isn't, we can also stop there, since no other components afterwards will be markers. In that case, we update EntityMarkers so the write_fns for that marker are used
- added markers to the protocol hash, since they affect both server and client so we need to make sure that the markers are registered on both
- added a unit test

So the extra cost is one marker-check for each Updates message.