### PR TITLE
 `ServerMutateTicks.last_confirmed_tick` cannot go backwards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Marker components are now part of the protocol (should be registered on both, client and server) and taken into account if they're is included as a part of the entity update.
+- Make sure that ServerMutateTicks.last_confirmed_tick cannot go backwards
 
 ## [0.42.2] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Marker components are now part of the protocol (should be registered on both, client and server) and taken into account if they're is included as a part of the entity update.
-- Make sure that ServerMutateTicks.last_confirmed_tick cannot go backwards
+
+### Fixed
+
+- Make sure that `ServerMutateTicks.last_confirmed_tick` cannot go backwards.
 
 ## [0.42.2] - 2026-08-14
 

--- a/src/client/server_mutate_ticks.rs
+++ b/src/client/server_mutate_ticks.rs
@@ -21,6 +21,7 @@ pub struct ServerMutateTicks {
     last_tick: RepliconTick,
 
     /// The latest server tick reported as fully received.
+    ///
     /// This can never go backwards, it represents a 'frontier' where the state on the
     /// server is guaranteed to be fully received by the client.
     last_confirmed_tick: Option<RepliconTick>,

--- a/src/client/server_mutate_ticks.rs
+++ b/src/client/server_mutate_ticks.rs
@@ -20,7 +20,9 @@ pub struct ServerMutateTicks {
     /// The last received server tick with mutation.
     last_tick: RepliconTick,
 
-    /// The last server tick reported as fully received.
+    /// The latest server tick reported as fully received.
+    /// This can never go backwards, it represents a 'frontier' where the state on the
+    /// server is guaranteed to be fully received by the client.
     last_confirmed_tick: Option<RepliconTick>,
 }
 
@@ -148,7 +150,9 @@ impl ServerMutateTicks {
     }
 
     pub(super) fn set_last_confirmed_tick(&mut self, tick: RepliconTick) {
-        self.last_confirmed_tick = Some(tick);
+        if self.last_confirmed_tick.is_none_or(|t| t.is_older(tick)) {
+            self.last_confirmed_tick = Some(tick);
+        }
     }
 }
 


### PR DESCRIPTION
Fix https://github.com/simgine/bevy_replicon/issues/745