### PR TITLE
perf: reuse cached data for similar archetypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Marker components are now part of the protocol (should be registered on both, client and server) and taken into account if they're is included as a part of the entity update.
+- Optimized the replication archetype cache by reusing the cached data for archetypes that have the same set of replication related components
 
 ## [0.42.3] - 2026-08-22
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -217,6 +217,14 @@ impl Plugin for ServerPlugin {
     }
 
     fn finish(&self, app: &mut App) {
+        app.world_mut().resource_scope(
+            |world, mut replicated_archetypes: Mut<ReplicatedArchetypes>| {
+                let rules = world.resource::<ReplicationRules>();
+                let receive_markers = world.resource::<ReceiveMarkers>();
+                replicated_archetypes.finalize(rules, receive_markers);
+            },
+        );
+
         // Multiple rules can include components with the same ID,
         // we collect them here to deduplicate.
         let rules = app.world().resource::<ReplicationRules>();
@@ -695,9 +703,9 @@ fn collect_changes(
 ) -> Result<()> {
     replicated_archetypes.update(archetypes, &rules, &receive_markers);
 
-    for replicated_archetype in replicated_archetypes.iter() {
+    for (archetype_id, replicated_archetype) in replicated_archetypes.iter() {
         // SAFETY: all IDs from replicated archetypes obtained from real archetypes.
-        let archetype = unsafe { archetypes.get(replicated_archetype.id).unwrap_unchecked() };
+        let archetype = unsafe { archetypes.get(archetype_id).unwrap_unchecked() };
 
         for entity in archetype.entities() {
             let mut entity_range = None;

--- a/src/server.rs
+++ b/src/server.rs
@@ -217,14 +217,6 @@ impl Plugin for ServerPlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        app.world_mut().resource_scope(
-            |world, mut replicated_archetypes: Mut<ReplicatedArchetypes>| {
-                let rules = world.resource::<ReplicationRules>();
-                let receive_markers = world.resource::<ReceiveMarkers>();
-                replicated_archetypes.finalize(rules, receive_markers);
-            },
-        );
-
         // Multiple rules can include components with the same ID,
         // we collect them here to deduplicate.
         let rules = app.world().resource::<ReplicationRules>();
@@ -237,11 +229,19 @@ impl Plugin for ServerPlugin {
         // Removal observer without any components will trigger on any removal.
         if !replicated_ids.is_empty() {
             let mut remove_observer = Observer::new(buffer_removals);
-            for id in replicated_ids {
+            for &id in &replicated_ids {
                 remove_observer = remove_observer.with_component(id);
             }
             app.world_mut().spawn(remove_observer);
         }
+
+        app.world_mut().resource_scope(
+            move |world, mut replicated_archetypes: Mut<ReplicatedArchetypes>| {
+                let rules = world.resource::<ReplicationRules>();
+                let receive_markers = world.resource::<ReceiveMarkers>();
+                replicated_archetypes.finalize(replicated_ids, rules, receive_markers);
+            },
+        );
 
         app.world_mut()
             .resource_scope(|world, mut messages: Mut<ServerMessages>| {

--- a/src/server/replicated_archetypes.rs
+++ b/src/server/replicated_archetypes.rs
@@ -2,7 +2,7 @@ use core::mem;
 
 use bevy::{
     ecs::{
-        archetype::{ArchetypeGeneration, ArchetypeId, Archetypes},
+        archetype::{Archetype, ArchetypeGeneration, ArchetypeId, Archetypes},
         component::{ComponentId, StorageType},
     },
     platform::collections::HashMap,
@@ -14,7 +14,7 @@ use crate::{
     prelude::*,
     shared::replication::{
         receive_markers::ReceiveMarkers,
-        rules::{ReplicationRules, component::ComponentRule},
+        rules::{ReplicationRules, component::ComponentRule, filter::FilterRule},
     },
 };
 
@@ -26,20 +26,50 @@ pub(super) struct ReplicatedArchetypes {
     /// Highest processed archetype ID.
     generation: ArchetypeGeneration,
 
-    /// Maps a Bevy archetype ID to an index in [`Self::list`].
+    /// Components whose presence can affect replication metadata.
+    key_components: Option<Box<[ComponentId]>>,
+
+    /// Maps replication-relevant archetype components to an index in [`Self::list`].
+    key_map: HashMap<ReplicationArchetypeKey, usize>,
+
+    /// Maps Bevy archetype IDs to an index in [`Self::list`].
     ids_map: HashMap<ArchetypeId, usize>,
 
-    /// Archetypes marked as replicated.
+    /// Cached metadata shared by archetypes with the same replication-relevant components.
     list: Vec<ReplicatedArchetype>,
 }
 
 impl ReplicatedArchetypes {
+    pub(super) fn finalize(&mut self, rules: &ReplicationRules, receive_markers: &ReceiveMarkers) {
+        assert!(
+            self.key_components.is_none(),
+            "replicated archetypes should be finalized only once"
+        );
+
+        let mut components = Vec::new();
+        for rule in rules.iter() {
+            components.extend(rule.components.iter().map(|component| component.id));
+            for filter in &rule.filters {
+                filter.push_components(&mut components);
+            }
+        }
+        components.extend(receive_markers.component_ids());
+        components.sort_unstable();
+        components.dedup();
+
+        self.key_components = Some(components.into_boxed_slice());
+    }
+
     pub(super) fn update(
         &mut self,
         archetypes: &Archetypes,
         rules: &ReplicationRules,
         receive_markers: &ReceiveMarkers,
     ) {
+        let key_components = self
+            .key_components
+            .as_deref()
+            .expect("replicated archetypes should be finalized before updating");
         let old_generation = mem::replace(&mut self.generation, archetypes.generation());
 
         for archetype in archetypes[old_generation..]
@@ -47,34 +77,44 @@ impl ReplicatedArchetypes {
             .filter(|archetype| archetype.contains(self.marker_id))
         {
             trace!("marking `{:?}` as replicated", archetype.id());
-            let mut replicated_archetype = ReplicatedArchetype::new(archetype.id());
-            for rule in rules.iter().filter(|rule| rule.matches(archetype)) {
-                for &component in &rule.components {
-                    // Since rules are sorted by priority,
-                    // we are inserting only new components that aren't present.
-                    if replicated_archetype
-                        .components
-                        .iter()
-                        .any(|(existing, _)| existing.id == component.id)
-                    {
-                        continue;
+            let key = ReplicationArchetypeKey::new(archetype, key_components);
+            let index = if let Some(&index) = self.key_map.get(&key) {
+                index
+            } else {
+                let mut replicated_archetype = ReplicatedArchetype::default();
+                for rule in rules.iter().filter(|rule| rule.matches(archetype)) {
+                    for &component in &rule.components {
+                        // Since rules are sorted by priority,
+                        // we are inserting only new components that aren't present.
+                        if replicated_archetype
+                            .components
+                            .iter()
+                            .any(|(existing, _)| existing.id == component.id)
+                        {
+                            continue;
+                        }
+
+                        // SAFETY: archetype matches the rule, so the component is present.
+                        let storage =
+                            unsafe { archetype.get_storage_type(component.id).unwrap_unchecked() };
+                        replicated_archetype.components.push((component, storage));
                     }
-
-                    // SAFETY: archetype matches the rule, so the component is present.
-                    let storage =
-                        unsafe { archetype.get_storage_type(component.id).unwrap_unchecked() };
-                    replicated_archetype.components.push((component, storage));
                 }
-            }
 
-            // Incoming receive markers need to be processed before other components so they can
-            // affect which receive functions are selected for the rest of the entity update.
-            replicated_archetype.components.sort_by_key(|(rule, _)| {
-                receive_markers.marker_index(rule.id).unwrap_or(usize::MAX)
-            });
+                // Incoming receive markers need to be processed before other components so they can
+                // affect which receive functions are selected for the rest of the entity update.
+                replicated_archetype.components.sort_by_key(|(rule, _)| {
+                    receive_markers.marker_index(rule.id).unwrap_or(usize::MAX)
+                });
 
-            self.ids_map.insert(archetype.id(), self.list.len());
-            self.list.push(replicated_archetype);
+                let index = self.list.len();
+                self.key_map.insert(key, index);
+                self.list.push(replicated_archetype);
+                index
+            };
+
+            self.ids_map.insert(archetype.id(), index);
+            self.list[index].ids.push(archetype.id());
         }
     }
 
@@ -87,8 +127,13 @@ impl ReplicatedArchetypes {
         self.list.get(index)
     }
 
-    pub(super) fn iter(&self) -> impl Iterator<Item = &ReplicatedArchetype> {
-        self.list.iter()
+    pub(super) fn iter(&self) -> impl Iterator<Item = (ArchetypeId, &ReplicatedArchetype)> {
+        self.list.iter().flat_map(|replicated_archetype| {
+            replicated_archetype
+                .ids
+                .iter()
+                .map(move |&id| (id, replicated_archetype))
+        })
     }
 }
 
@@ -97,29 +142,60 @@ impl FromWorld for ReplicatedArchetypes {
         Self {
             marker_id: world.register_component::<Replicated>(),
             generation: ArchetypeGeneration::initial(),
+            key_components: None,
+            key_map: Default::default(),
             ids_map: Default::default(),
             list: Default::default(),
         }
     }
 }
 
+/// Presence of all components that can affect replication metadata for an archetype.
+#[derive(PartialEq, Eq, Hash)]
+struct ReplicationArchetypeKey(Vec<ComponentId>);
+
+impl ReplicationArchetypeKey {
+    fn new(archetype: &Archetype, key_components: &[ComponentId]) -> Self {
+        Self(
+            key_components
+                .iter()
+                .copied()
+                .filter(|&id| archetype.contains(id))
+                .collect(),
+        )
+    }
+}
+
+/// Collects filter components whose presence can affect a replication archetype key.
+trait FilterRuleKeyExt {
+    /// Appends component IDs referenced by this filter, including nested [`FilterRule::Or`]s.
+    fn push_components(&self, components: &mut Vec<ComponentId>);
+}
+
+impl FilterRuleKeyExt for FilterRule {
+    fn push_components(&self, components: &mut Vec<ComponentId>) {
+        match self {
+            Self::With(id) | Self::Without(id) => components.push(*id),
+            Self::Or(filters) => {
+                for filter in filters {
+                    filter.push_components(components);
+                }
+            }
+        }
+    }
+}
+
 /// An archetype that can be stored in [`ReplicatedArchetypes`].
+#[derive(Default)]
 pub(super) struct ReplicatedArchetype {
-    /// Associated archetype ID.
-    pub(super) id: ArchetypeId,
+    /// IDs of Bevy archetypes that share this replication metadata.
+    ids: Vec<ArchetypeId>,
 
     /// Components marked as replicated.
     pub(super) components: Vec<(ComponentRule, StorageType)>,
 }
 
 impl ReplicatedArchetype {
-    fn new(id: ArchetypeId) -> Self {
-        Self {
-            id,
-            components: Default::default(),
-        }
-    }
-
     pub(super) fn find_rule(&self, id: ComponentId) -> Option<&ComponentRule> {
         self.components.iter().map(|(r, _)| r).find(|r| r.id == id)
     }
@@ -180,6 +256,90 @@ mod tests {
         assert_eq!(archetypes.list.len(), 1);
         let archetype = archetypes.list.first().unwrap();
         assert_eq!(archetype.components.len(), 1);
+    }
+
+    #[test]
+    fn shares_metadata_for_unrelated_components() {
+        let mut app = App::new();
+        app.init_resource::<ReplicatedArchetypes>()
+            .init_resource::<ReplicationRules>()
+            .init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRegistry>()
+            .init_resource::<ReceiveMarkers>()
+            .replicate::<A>();
+
+        app.world_mut().spawn((Replicated, A));
+        app.world_mut().spawn((Replicated, A, Unrelated));
+        update_archetypes(&mut app);
+
+        let archetypes = app.world().resource::<ReplicatedArchetypes>();
+        assert_eq!(archetypes.key_map.len(), 1);
+        assert_eq!(archetypes.list.len(), 1);
+        assert_eq!(archetypes.ids_map.len(), 2);
+        assert!(archetypes.ids_map.values().all(|&index| index == 0));
+        assert_eq!(archetypes.list[0].ids.len(), 2);
+    }
+
+    #[test]
+    fn separates_metadata_for_filter_components() {
+        let mut app = App::new();
+        app.init_resource::<ReplicatedArchetypes>()
+            .init_resource::<ReplicationRules>()
+            .init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRegistry>()
+            .init_resource::<ReceiveMarkers>()
+            .replicate_filtered::<A, Or<(With<B>, With<C>)>>();
+
+        let first = app.world_mut().spawn((Replicated, A)).archetype().id();
+        let second = app.world_mut().spawn((Replicated, A, B)).archetype().id();
+        let third = app
+            .world_mut()
+            .spawn((Replicated, A, Unrelated))
+            .archetype()
+            .id();
+        update_archetypes(&mut app);
+
+        let archetypes = app.world().resource::<ReplicatedArchetypes>();
+        assert_eq!(archetypes.key_map.len(), 2);
+        assert_eq!(archetypes.list.len(), 2);
+        assert_eq!(
+            archetypes
+                .iter()
+                .map(|(archetype_id, _)| archetype_id)
+                .collect::<Vec<_>>(),
+            [first, third, second]
+        );
+        assert!(
+            archetypes
+                .list
+                .iter()
+                .any(|archetype| archetype.components.is_empty())
+        );
+        assert!(
+            archetypes
+                .list
+                .iter()
+                .any(|archetype| archetype.components.len() == 1)
+        );
+    }
+
+    #[test]
+    fn separates_metadata_for_receive_markers() {
+        let mut app = App::new();
+        app.init_resource::<ReplicatedArchetypes>()
+            .init_resource::<ReplicationRules>()
+            .init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRegistry>()
+            .init_resource::<ReceiveMarkers>()
+            .register_marker::<Marker>();
+
+        app.world_mut().spawn(Replicated);
+        app.world_mut().spawn((Replicated, Marker));
+        update_archetypes(&mut app);
+
+        let archetypes = app.world().resource::<ReplicatedArchetypes>();
+        assert_eq!(archetypes.key_map.len(), 2);
+        assert_eq!(archetypes.list.len(), 2);
     }
 
     #[test]
@@ -286,6 +446,9 @@ mod tests {
             .resource_scope(|world, mut archetypes: Mut<ReplicatedArchetypes>| {
                 let rules = world.resource::<ReplicationRules>();
                 let receive_markers = world.resource::<ReceiveMarkers>();
+                if archetypes.key_components.is_none() {
+                    archetypes.finalize(rules, receive_markers);
+                }
                 archetypes.update(world.archetypes(), rules, receive_markers);
             });
     }
@@ -298,4 +461,10 @@ mod tests {
 
     #[derive(Component, Serialize, Deserialize)]
     struct C;
+
+    #[derive(Component)]
+    struct Unrelated;
+
+    #[derive(Component)]
+    struct Marker;
 }

--- a/src/server/replicated_archetypes.rs
+++ b/src/server/replicated_archetypes.rs
@@ -1,11 +1,17 @@
-use core::mem;
+use core::{
+    hash::{BuildHasher, Hash, Hasher},
+    mem,
+};
 
 use bevy::{
     ecs::{
         archetype::{Archetype, ArchetypeGeneration, ArchetypeId, Archetypes},
         component::{ComponentId, StorageType},
     },
-    platform::collections::HashMap,
+    platform::{
+        collections::{HashMap, HashSet},
+        hash::{FixedHasher, NoOpHash},
+    },
     prelude::*,
 };
 use log::trace;
@@ -30,7 +36,7 @@ pub(super) struct ReplicatedArchetypes {
     key_components: Option<Box<[ComponentId]>>,
 
     /// Maps replication-relevant archetype components to an index in [`Self::list`].
-    key_map: HashMap<ReplicationArchetypeKey, usize>,
+    key_map: HashMap<ReplicationArchetypeKey, usize, NoOpHash>,
 
     /// Maps Bevy archetype IDs to an index in [`Self::list`].
     ids_map: HashMap<ArchetypeId, usize>,
@@ -40,24 +46,32 @@ pub(super) struct ReplicatedArchetypes {
 }
 
 impl ReplicatedArchetypes {
-    pub(super) fn finalize(&mut self, rules: &ReplicationRules, receive_markers: &ReceiveMarkers) {
+    /// Finalizes the components used to distinguish replication archetypes.
+    ///
+    /// # Arguments
+    ///
+    /// * `components` - Deduplicated component IDs from all replication rules.
+    /// * `rules` - Replication rules whose filter components should also affect the key.
+    /// * `receive_markers` - Marker component IDs that can alter receive behavior.
+    pub(super) fn finalize(
+        &mut self,
+        mut components: HashSet<ComponentId>,
+        rules: &ReplicationRules,
+        receive_markers: &ReceiveMarkers,
+    ) {
         assert!(
             self.key_components.is_none(),
             "replicated archetypes should be finalized only once"
         );
 
-        let mut components = Vec::new();
         for rule in rules.iter() {
-            components.extend(rule.components.iter().map(|component| component.id));
             for filter in &rule.filters {
                 filter.push_components(&mut components);
             }
         }
         components.extend(receive_markers.component_ids());
-        components.sort_unstable();
-        components.dedup();
 
-        self.key_components = Some(components.into_boxed_slice());
+        self.key_components = Some(components.into_iter().collect());
     }
 
     pub(super) fn update(
@@ -150,32 +164,32 @@ impl FromWorld for ReplicatedArchetypes {
     }
 }
 
-/// Presence of all components that can affect replication metadata for an archetype.
+/// Hash of all components whose presence affects replication metadata for an archetype.
 #[derive(PartialEq, Eq, Hash)]
-struct ReplicationArchetypeKey(Vec<ComponentId>);
+struct ReplicationArchetypeKey(u64);
 
 impl ReplicationArchetypeKey {
     fn new(archetype: &Archetype, key_components: &[ComponentId]) -> Self {
-        Self(
-            key_components
-                .iter()
-                .copied()
-                .filter(|&id| archetype.contains(id))
-                .collect(),
-        )
+        let mut hasher = FixedHasher.build_hasher();
+        for id in key_components.iter().filter(|&&id| archetype.contains(id)) {
+            id.hash(&mut hasher);
+        }
+        Self(hasher.finish())
     }
 }
 
 /// Collects filter components whose presence can affect a replication archetype key.
 trait FilterRuleKeyExt {
     /// Appends component IDs referenced by this filter, including nested [`FilterRule::Or`]s.
-    fn push_components(&self, components: &mut Vec<ComponentId>);
+    fn push_components(&self, components: &mut HashSet<ComponentId>);
 }
 
 impl FilterRuleKeyExt for FilterRule {
-    fn push_components(&self, components: &mut Vec<ComponentId>) {
+    fn push_components(&self, components: &mut HashSet<ComponentId>) {
         match self {
-            Self::With(id) | Self::Without(id) => components.push(*id),
+            Self::With(id) | Self::Without(id) => {
+                components.insert(*id);
+            }
             Self::Or(filters) => {
                 for filter in filters {
                     filter.push_components(components);
@@ -447,7 +461,12 @@ mod tests {
                 let rules = world.resource::<ReplicationRules>();
                 let receive_markers = world.resource::<ReceiveMarkers>();
                 if archetypes.key_components.is_none() {
-                    archetypes.finalize(rules, receive_markers);
+                    let replicated_ids = rules
+                        .iter()
+                        .flat_map(|rule| &rule.components)
+                        .map(|component| component.id)
+                        .collect();
+                    archetypes.finalize(replicated_ids, rules, receive_markers);
                 }
                 archetypes.update(world.archetypes(), rules, receive_markers);
             });

--- a/src/shared/replication/receive_markers.rs
+++ b/src/shared/replication/receive_markers.rs
@@ -283,6 +283,10 @@ impl ReceiveMarkers {
             .position(|marker| marker.component_id == component_id)
     }
 
+    pub(crate) fn component_ids(&self) -> impl Iterator<Item = ComponentId> + '_ {
+        self.0.iter().map(|marker| marker.component_id)
+    }
+
     pub(super) fn iter_require_history(&self) -> impl Iterator<Item = bool> + '_ {
         self.0.iter().map(|marker| marker.config.need_history)
     }


### PR DESCRIPTION
I noticed that we cache every single archetype that has `Replicated`.

In big apps we could have hundreds of archetypes that are similar, but differ only by non-replicated components. In that case we can re-use a single cached list of components to replicate.
We compute a Key from the ordered list of components that affect replication across all rules (markers, filters, replicated components).