### PR TITLE
Add `apply_in_same_update` on marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Include receive markers in the protocol only when `MarkerConfig::apply_in_same_update` is enabled, allowing other markers to be registered only on clients.
+
 ## [0.43.0] - 2026-08-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Changelog
 
 - Include receive markers in the protocol only when `MarkerConfig::affects_same_update` is enabled, allowing other markers to be registered only on clients.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Include receive markers in the protocol only when `MarkerConfig::apply_in_same_update` is enabled, allowing other markers to be registered only on clients.
+- Include receive markers in the protocol only when `MarkerConfig::affects_same_update` is enabled, allowing other markers to be registered only on clients.
 
 ## [0.43.0] - 2026-08-28
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -588,9 +588,9 @@ fn apply_changes(
     confirm_tick(&mut client_entity, params.replicated, message_tick);
 
     let mut data = message.split_to(data_size);
-    // The server sorts incoming same-update markers from highest to lowest priority before all
-    // other components. Only the first component needs to be checked because, if it's a marker,
-    // lower-priority markers can't affect receive-function selection.
+    // The server sorts incoming markers with `affects_same_update` from highest to lowest priority
+    // before all other components. Only the first component needs to be checked because, if it's a
+    // marker, lower-priority markers can't affect receive-function selection.
     let mut first_component = true;
     let len = apply_array(ArrayKind::Dynamic, &mut data, |data| {
         let spawner = BufferedSpawner::new(entity_allocator, params.entity_buffer);

--- a/src/client.rs
+++ b/src/client.rs
@@ -588,8 +588,8 @@ fn apply_changes(
     confirm_tick(&mut client_entity, params.replicated, message_tick);
 
     let mut data = message.split_to(data_size);
-    // The server sorts incoming markers from highest to lowest priority before all other
-    // components. Only the first component needs to be checked because, if it's a marker,
+    // The server sorts incoming same-update markers from highest to lowest priority before all
+    // other components. Only the first component needs to be checked because, if it's a marker,
     // lower-priority markers can't affect receive-function selection.
     let mut first_component = true;
     let len = apply_array(ArrayKind::Dynamic, &mut data, |data| {

--- a/src/server/replicated_archetypes.rs
+++ b/src/server/replicated_archetypes.rs
@@ -67,8 +67,7 @@ impl ReplicatedArchetypes {
                 }
             }
 
-            // Incoming same-update markers need to be processed before other components so they
-            // can affect which receive functions are selected for the rest of the entity update.
+            // Incoming receive markers that take effect in the same update should be processed first.
             replicated_archetype.components.sort_by_key(|(rule, _)| {
                 receive_markers
                     .same_update_marker_index(rule.id)

--- a/src/server/replicated_archetypes.rs
+++ b/src/server/replicated_archetypes.rs
@@ -67,10 +67,12 @@ impl ReplicatedArchetypes {
                 }
             }
 
-            // Incoming receive markers need to be processed before other components so they can
-            // affect which receive functions are selected for the rest of the entity update.
+            // Incoming same-update markers need to be processed before other components so they
+            // can affect which receive functions are selected for the rest of the entity update.
             replicated_archetype.components.sort_by_key(|(rule, _)| {
-                receive_markers.marker_index(rule.id).unwrap_or(usize::MAX)
+                receive_markers
+                    .same_update_marker_index(rule.id)
+                    .unwrap_or(usize::MAX)
             });
 
             self.ids_map.insert(archetype.id(), self.list.len());

--- a/src/shared/replication/receive_markers.rs
+++ b/src/shared/replication/receive_markers.rs
@@ -22,8 +22,9 @@ pub trait AppMarkerExt {
     /// based on marker-component presence.
     /// For details see [`Self::set_marker_fns`].
     ///
-    /// Marker registration is part of the protocol and should be performed in the same order
-    /// on the client and server.
+    /// Marker registration is part of the protocol only when
+    /// [`MarkerConfig::apply_in_same_update`] is enabled. Other markers can be registered only on
+    /// the client.
     ///
     /// This function registers markers with default [`MarkerConfig`].
     /// See also [`Self::register_marker_with`].
@@ -187,9 +188,11 @@ impl AppMarkerExt for App {
 
     fn register_marker_with<M: Component>(&mut self, config: MarkerConfig) -> &mut Self {
         debug!("registering marker `{}`", ShortName::of::<M>());
-        self.world_mut()
-            .resource_mut::<ProtocolHasher>()
-            .register_marker::<M>(config.priority, config.need_history);
+        if config.apply_in_same_update {
+            self.world_mut()
+                .resource_mut::<ProtocolHasher>()
+                .register_marker::<M>(config.priority, config.need_history);
+        }
         let component_id = self.world_mut().register_component::<M>();
         let mut receive_markers = self.world_mut().resource_mut::<ReceiveMarkers>();
         let marker_id = receive_markers.insert(ReceiveMarker {
@@ -283,6 +286,13 @@ impl ReceiveMarkers {
             .position(|marker| marker.component_id == component_id)
     }
 
+    /// Returns the marker's position if it's configured to apply in the same update.
+    pub(crate) fn same_update_marker_index(&self, component_id: ComponentId) -> Option<usize> {
+        self.0.iter().position(|marker| {
+            marker.component_id == component_id && marker.config.apply_in_same_update
+        })
+    }
+
     pub(super) fn iter_require_history(&self) -> impl Iterator<Item = bool> + '_ {
         self.0.iter().map(|marker| marker.config.need_history)
     }
@@ -319,6 +329,23 @@ pub struct MarkerConfig {
     ///
     /// By default set to `false`.
     pub need_history: bool,
+
+    /// Makes a replicated marker take effect before other components from the same entity update
+    /// are applied.
+    ///
+    /// When enabled, the sender orders this marker before other replicated components, allowing
+    /// its receive functions to be selected for the rest of the update. The marker registration
+    /// becomes part of the protocol and must use the same configuration and registration order on
+    /// the client and server.
+    ///
+    /// This option doesn't replicate the marker component by itself. A replication rule for the
+    /// marker must be registered separately.
+    ///
+    /// When disabled, the marker isn't added to the protocol or prioritized by the server, so it
+    /// can be registered only on the client.
+    ///
+    /// By default set to `false`.
+    pub apply_in_same_update: bool,
 }
 
 /// Stores which markers are present on an entity.
@@ -346,11 +373,12 @@ impl EntityMarkers {
         }
     }
 
-    /// Includes a marker component that is about to be inserted on the entity.
+    /// Includes a same-update marker component that is about to be inserted on the entity.
     ///
-    /// Returns `true` if `component_id` belongs to a registered marker.
+    /// Returns `true` if `component_id` belongs to a marker configured with
+    /// [`MarkerConfig::apply_in_same_update`].
     pub(crate) fn include(&mut self, markers: &ReceiveMarkers, component_id: ComponentId) -> bool {
-        let Some(index) = markers.marker_index(component_id) else {
+        let Some(index) = markers.same_update_marker_index(component_id) else {
             return false;
         };
 
@@ -437,6 +465,34 @@ mod tests {
     }
 
     #[test]
+    fn protocol_includes_only_same_update_markers() {
+        let mut app = App::new();
+        app.init_resource::<ReceiveMarkers>()
+            .init_resource::<ReplicationRegistry>()
+            .init_resource::<ProtocolHasher>()
+            .register_marker_with::<MarkerA>(MarkerConfig {
+                need_history: true,
+                ..Default::default()
+            })
+            .register_marker_with::<MarkerB>(MarkerConfig {
+                priority: 2,
+                apply_in_same_update: true,
+                ..Default::default()
+            });
+
+        let markers = app.world().resource::<ReceiveMarkers>();
+        let marker_a_id = app.world().component_id::<MarkerA>().unwrap();
+        let marker_b_id = app.world().component_id::<MarkerB>().unwrap();
+        assert_eq!(markers.same_update_marker_index(marker_a_id), None);
+        assert!(markers.same_update_marker_index(marker_b_id).is_some());
+
+        let actual = app.world_mut().remove_resource::<ProtocolHasher>().unwrap();
+        let mut expected = ProtocolHasher::default();
+        expected.register_marker::<MarkerB>(2, false);
+        assert_eq!(actual.finish(), expected.finish());
+    }
+
+    #[test]
     fn include() {
         let mut app = App::new();
         app.init_resource::<ReceiveMarkers>()
@@ -444,6 +500,7 @@ mod tests {
             .init_resource::<ProtocolHasher>()
             .register_marker_with::<Marker>(MarkerConfig {
                 need_history: true,
+                apply_in_same_update: true,
                 ..Default::default()
             });
 

--- a/src/shared/replication/receive_markers.rs
+++ b/src/shared/replication/receive_markers.rs
@@ -465,7 +465,7 @@ mod tests {
     }
 
     #[test]
-    fn protocol_includes_only_same_update_markers() {
+    fn affects_same_update() {
         let mut app = App::new();
         app.init_resource::<ReceiveMarkers>()
             .init_resource::<ReplicationRegistry>()
@@ -489,7 +489,11 @@ mod tests {
         let actual = app.world_mut().remove_resource::<ProtocolHasher>().unwrap();
         let mut expected = ProtocolHasher::default();
         expected.register_marker::<MarkerB>(2, false);
-        assert_eq!(actual.finish(), expected.finish());
+        assert_eq!(
+            actual.finish(),
+            expected.finish(),
+            "should include only the marker that affects the same update"
+        );
     }
 
     #[test]

--- a/src/shared/replication/receive_markers.rs
+++ b/src/shared/replication/receive_markers.rs
@@ -23,7 +23,7 @@ pub trait AppMarkerExt {
     /// For details see [`Self::set_marker_fns`].
     ///
     /// Marker registration is part of the protocol only when
-    /// [`MarkerConfig::apply_in_same_update`] is enabled. Other markers can be registered only on
+    /// [`MarkerConfig::affects_same_update`] is enabled. Other markers can be registered only on
     /// the client.
     ///
     /// This function registers markers with default [`MarkerConfig`].
@@ -188,7 +188,7 @@ impl AppMarkerExt for App {
 
     fn register_marker_with<M: Component>(&mut self, config: MarkerConfig) -> &mut Self {
         debug!("registering marker `{}`", ShortName::of::<M>());
-        if config.apply_in_same_update {
+        if config.affects_same_update {
             self.world_mut()
                 .resource_mut::<ProtocolHasher>()
                 .register_marker::<M>(config.priority, config.need_history);
@@ -289,7 +289,7 @@ impl ReceiveMarkers {
     /// Returns the marker's position if it's configured to apply in the same update.
     pub(crate) fn same_update_marker_index(&self, component_id: ComponentId) -> Option<usize> {
         self.0.iter().position(|marker| {
-            marker.component_id == component_id && marker.config.apply_in_same_update
+            marker.component_id == component_id && marker.config.affects_same_update
         })
     }
 
@@ -345,7 +345,7 @@ pub struct MarkerConfig {
     /// can be registered only on the client.
     ///
     /// By default set to `false`.
-    pub apply_in_same_update: bool,
+    pub affects_same_update: bool,
 }
 
 /// Stores which markers are present on an entity.
@@ -376,7 +376,7 @@ impl EntityMarkers {
     /// Includes a same-update marker component that is about to be inserted on the entity.
     ///
     /// Returns `true` if `component_id` belongs to a marker configured with
-    /// [`MarkerConfig::apply_in_same_update`].
+    /// [`MarkerConfig::affects_same_update`].
     pub(crate) fn include(&mut self, markers: &ReceiveMarkers, component_id: ComponentId) -> bool {
         let Some(index) = markers.same_update_marker_index(component_id) else {
             return false;
@@ -476,7 +476,7 @@ mod tests {
             })
             .register_marker_with::<MarkerB>(MarkerConfig {
                 priority: 2,
-                apply_in_same_update: true,
+                affects_same_update: true,
                 ..Default::default()
             });
 
@@ -500,7 +500,7 @@ mod tests {
             .init_resource::<ProtocolHasher>()
             .register_marker_with::<Marker>(MarkerConfig {
                 need_history: true,
-                apply_in_same_update: true,
+                affects_same_update: true,
                 ..Default::default()
             });
 

--- a/src/shared/replication/receive_markers.rs
+++ b/src/shared/replication/receive_markers.rs
@@ -22,9 +22,9 @@ pub trait AppMarkerExt {
     /// based on marker-component presence.
     /// For details see [`Self::set_marker_fns`].
     ///
-    /// Marker registration is part of the protocol only when
-    /// [`MarkerConfig::affects_same_update`] is enabled. Other markers can be registered only on
-    /// the client.
+    /// By default, markers need to be registered only on the client. However, if
+    /// [`MarkerConfig::affects_same_update`] is enabled, marker registration becomes part of the
+    /// protocol and should be performed in the same order on the client and server.
     ///
     /// This function registers markers with default [`MarkerConfig`].
     /// See also [`Self::register_marker_with`].
@@ -334,7 +334,7 @@ pub struct MarkerConfig {
     /// are applied.
     ///
     /// When enabled, the sender orders this marker before other replicated components, allowing
-    /// its receive functions to be selected for the rest of the update. The marker registration
+    /// its receive functions to be selected for the rest of the update. Marker registration
     /// becomes part of the protocol and must use the same configuration and registration order on
     /// the client and server.
     ///
@@ -342,7 +342,7 @@ pub struct MarkerConfig {
     /// marker must be registered separately.
     ///
     /// When disabled, the marker isn't added to the protocol or prioritized by the server, so it
-    /// can be registered only on the client.
+    /// only needs to be registered on the client.
     ///
     /// By default set to `false`.
     pub affects_same_update: bool,
@@ -373,7 +373,7 @@ impl EntityMarkers {
         }
     }
 
-    /// Includes a same-update marker component that is about to be inserted on the entity.
+    /// Includes a marker component that is about to be inserted on the entity.
     ///
     /// Returns `true` if `component_id` belongs to a marker configured with
     /// [`MarkerConfig::affects_same_update`].

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -393,24 +393,20 @@ fn receive_fns() {
 fn client_only_marker() {
     let mut server_app = App::new();
     let mut client_app = App::new();
-    server_app
-        .add_plugins((
-            MinimalPlugins,
-            StatesPlugin,
-            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
-        ))
-        .replicate::<Original>()
-        .finish();
-    client_app
-        .add_plugins((
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .register_marker::<ReplaceMarker>()
-        .replicate::<Original>()
-        .set_marker_fns::<ReplaceMarker, _>(replace, receive_fns::default_remove::<Replaced>)
-        .finish();
+        .replicate::<Original>();
+    }
+
+    client_app.set_marker_fns::<ReplaceMarker, _>(replace, receive_fns::default_remove::<Replaced>);
+
+    server_app.finish();
+    client_app.finish();
 
     server_app.connect_client(&mut client_app);
 

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -457,7 +457,7 @@ fn marker_from_same_update() {
             RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .register_marker_with::<ReplaceMarker>(MarkerConfig {
-            apply_in_same_update: true,
+            affects_same_update: true,
             ..Default::default()
         })
         // Register the regular component first to verify that receive markers are reordered.

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -6,6 +6,7 @@ use bevy_replicon::{
     shared::{
         replication::{
             deferred_entity::DeferredEntity,
+            receive_markers::MarkerConfig,
             registry::{ctx::WriteCtx, receive_fns},
         },
         server_entity_map::ServerEntityMap,
@@ -389,11 +390,19 @@ fn receive_fns() {
 }
 
 #[test]
-fn marker() {
+fn client_only_marker() {
     let mut server_app = App::new();
     let mut client_app = App::new();
-    for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((
+    server_app
+        .add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .replicate::<Original>()
+        .finish();
+    client_app
+        .add_plugins((
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
@@ -402,7 +411,6 @@ fn marker() {
         .replicate::<Original>()
         .set_marker_fns::<ReplaceMarker, _>(replace, receive_fns::default_remove::<Replaced>)
         .finish();
-    }
 
     server_app.connect_client(&mut client_app);
 
@@ -448,7 +456,10 @@ fn marker_from_same_update() {
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
-        .register_marker::<ReplaceMarker>()
+        .register_marker_with::<ReplaceMarker>(MarkerConfig {
+            apply_in_same_update: true,
+            ..Default::default()
+        })
         // Register the regular component first to verify that receive markers are reordered.
         .replicate::<Original>()
         .set_marker_fns::<ReplaceMarker, _>(replace, receive_fns::default_remove::<Replaced>)


### PR DESCRIPTION
If enabled: markers that are replicated as part of an Update message will be inserted first, and will affect the replication function that will be used on the receiver.
If that's the case, the marker needs to be registered on the server, since the server needs to be aware of the markers (to order them at the start of the Update message). This is tested by including the marker in the ProtocolHash.

If this option is disabled, then the marker can remain client-only.