### PR TITLE
Make ClientVisibility::get pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changes
+
+- ClientVisilibity::get is now public and be used to access the `FiltersMask` bitmask of an entity.
+
 ## [0.44.0] - 2026-09-01
 
 ### Changed

--- a/src/server/visibility/client_visibility.rs
+++ b/src/server/visibility/client_visibility.rs
@@ -165,7 +165,7 @@ impl ClientVisibility {
     }
 
     /// Returns bits for all filters that affect visibility of the given entity.
-    pub(crate) fn get(&self, entity: Entity) -> FiltersMask {
+    pub fn get(&self, entity: Entity) -> FiltersMask {
         self.hidden.get(&entity).copied().unwrap_or_default()
     }
 }

--- a/src/server/visibility/filters_mask.rs
+++ b/src/server/visibility/filters_mask.rs
@@ -12,7 +12,7 @@ use crate::{
 ///
 /// If the bit is set, it means that this filter hides its associated data.
 #[derive(Default, Reflect, Debug, PartialEq, Clone, Copy)]
-pub(crate) struct FiltersMask(u32);
+pub struct FiltersMask(u32);
 
 impl FiltersMask {
     pub(super) fn insert(&mut self, bit: FilterBit) {
@@ -23,16 +23,18 @@ impl FiltersMask {
         self.0 &= !(1 << *bit);
     }
 
-    pub(super) fn contains(&self, bit: FilterBit) -> bool {
+    /// Returns `true` if the given filter hides the entity's data.
+    pub fn contains(&self, bit: FilterBit) -> bool {
         (self.0 & (1 << *bit)) != 0
     }
 
-    pub(super) fn is_empty(&self) -> bool {
+    /// Returns `true` if no filter hides the entity's data.
+    pub fn is_empty(&self) -> bool {
         self.0 == 0
     }
 
     /// Returns an iterator over all set bits, in ascending bit order.
-    fn iter(self) -> impl Iterator<Item = FilterBit> {
+    pub fn iter(self) -> impl Iterator<Item = FilterBit> {
         let mut mask = self.0;
         iter::from_fn(move || {
             if mask == 0 {
@@ -118,7 +120,7 @@ impl FilterBit {
     /// Creates a new instance for the given bit index.
     ///
     /// Valid values are in the range `[0, 32)` that map directly to bits in [`FiltersMask`].
-    pub(super) fn new(value: u8) -> Self {
+    pub fn new(value: u8) -> Self {
         debug_assert!(value < 32, "filter bit must be less than {}", u32::BITS);
         Self(value)
     }


### PR DESCRIPTION
Can be used to make child entities inherit the FiltersMask bitset of their parent.