### PR TITLE
Enable delaying application of replication messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ShouldApplyReplication` event which which allows to defer message application.
+
 ### Changes
 
 - ClientVisilibity::get is now public and be used to access the `FiltersMask` bitmask of an entity.

--- a/src/client.rs
+++ b/src/client.rs
@@ -256,12 +256,11 @@ fn apply_replication(
     // newer update tick. This is intended: a mutation can only be applied after
     // the updates for ticks before it have been applied.
     while buffered_updates
-        .0
         .front()
         .is_some_and(|update| should_apply_update(world, update))
     {
-        let mut update = buffered_updates.0.pop_front().unwrap();
-        apply_update_or_log(world, params, &mut update);
+        let mut update = buffered_updates.pop_front().unwrap();
+        try_apply_update(world, params, &mut update);
     }
 
     for message in messages.drain_received(ServerChannel::Updates) {
@@ -273,13 +272,11 @@ fn apply_replication(
             }
         };
 
-        // The common case stays allocation-free: apply directly unless this update
-        // or an earlier ordered update needs to wait.
-        if buffered_updates.0.is_empty() && should_apply_update(world, &update) {
-            apply_update_or_log(world, params, &mut update);
+        if buffered_updates.is_empty() && should_apply_update(world, &update) {
+            try_apply_update(world, params, &mut update);
         } else {
             trace!("buffering update message for {:?}", update.message_tick);
-            buffered_updates.0.push_back(update);
+            buffered_updates.push_back(update);
         }
     }
 
@@ -297,12 +294,10 @@ fn apply_replication(
                 error!("unable to buffer mutate message: {e}");
             }
         }
-        if !acks.is_empty() {
-            messages.send(ClientChannel::MutationAcks, acks);
-        }
+        messages.send(ClientChannel::MutationAcks, acks);
     }
 
-    buffered_mutations.0.retain_mut(|mutate| {
+    buffered_mutations.retain_mut(|mutate| {
         if mutate.update_tick.is_newer(*update_tick) {
             return true;
         }
@@ -326,7 +321,7 @@ fn apply_replication(
     });
 }
 
-fn apply_update_or_log(world: &mut World, params: &mut ReceiveParams, update: &mut BufferedUpdate) {
+fn try_apply_update(world: &mut World, params: &mut ReceiveParams, update: &mut BufferedUpdate) {
     if let Err(e) = apply_update_message(world, params, update) {
         error!(
             "unable to apply update message for tick `{:?}`: {e}",
@@ -351,10 +346,9 @@ fn receive_update_message(
         stats.bytes += message.len();
     }
 
-    let mut flags: UpdateFlags = postcard_utils::from_buf(&mut message)?;
+    let flags: UpdateFlags = postcard_utils::from_buf(&mut message)?;
     let message_tick = postcard_utils::from_buf(&mut message)?;
     let userdata = if flags.contains(UpdateFlags::USERDATA) {
-        flags.remove(UpdateFlags::USERDATA);
         Some(receive_userdata(&mut message)?)
     } else {
         None
@@ -380,10 +374,6 @@ fn apply_update_message(
     );
     world.resource_mut::<ServerUpdateTick>().0 = update.message_tick;
 
-    if let Some(bytes) = update.userdata.take() {
-        apply_userdata(world, update.message_tick, bytes);
-    }
-
     let last_flag = update.flags.last();
     for (_, flag) in update.flags.iter_names() {
         let array_kind = if flag != last_flag {
@@ -393,6 +383,13 @@ fn apply_update_message(
         };
 
         match flag {
+            UpdateFlags::USERDATA => {
+                let bytes = update
+                    .userdata
+                    .take()
+                    .expect("userdata should be present because the USERDATA flag is set");
+                apply_userdata(world, update.message_tick, bytes);
+            }
             UpdateFlags::MAPPINGS => {
                 let len = apply_array(array_kind, &mut update.message, |message| {
                     apply_entity_mapping(world, params, message)
@@ -453,12 +450,11 @@ fn buffer_mutate_message(
         stats.bytes += message.len();
     }
 
-    let mut flags: MutateFlags = postcard_utils::from_buf(&mut message)?;
+    let flags: MutateFlags = postcard_utils::from_buf(&mut message)?;
     let mutate_index: MutateIndex = postcard_utils::from_buf(&mut message)?;
     let update_tick = postcard_utils::from_buf(&mut message)?;
     let message_tick = postcard_utils::from_buf(&mut message)?;
     let userdata = if flags.contains(MutateFlags::USERDATA) {
-        flags.remove(MutateFlags::USERDATA);
         Some(receive_userdata(&mut message)?)
     } else {
         None
@@ -489,12 +485,15 @@ fn apply_mutate_message(
         mutate.flags, mutate.message_tick
     );
 
-    if let Some(bytes) = mutate.userdata.take() {
-        apply_userdata(world, mutate.message_tick, bytes);
-    }
-
     for (_, flag) in mutate.flags.iter_names() {
         match flag {
+            MutateFlags::USERDATA => {
+                let bytes = mutate
+                    .userdata
+                    .take()
+                    .expect("userdata should be present because the USERDATA flag is set");
+                apply_userdata(world, mutate.message_tick, bytes);
+            }
             MutateFlags::MESSAGES_COUNT => {
                 confirm_mutate_tick(world, params.mutate_ticks, mutate)
                     .map_err(|e| format!("unable to confirm mutate tick: {e}"))?;
@@ -1065,14 +1064,8 @@ pub type ReplicationApplyFn = for<'a> fn(&World, RepliconTick, Option<UserDataBy
 pub struct ServerUpdateTick(RepliconTick);
 
 /// Cached ordered update messages deferred by [`ReplicationApplyPolicy`].
-#[derive(Resource, Default)]
+#[derive(Resource, Default, Deref, DerefMut)]
 struct BufferedUpdates(VecDeque<BufferedUpdate>);
-
-impl BufferedUpdates {
-    fn clear(&mut self) {
-        self.0.clear();
-    }
-}
 
 /// Partially-deserialized update message waiting for the user policy.
 struct BufferedUpdate {
@@ -1086,19 +1079,13 @@ struct BufferedUpdate {
 }
 
 /// Cached buffered mutate messages, used to synchronize mutations with update messages.
-#[derive(Resource, Default)]
+#[derive(Resource, Default, Deref, DerefMut)]
 pub(crate) struct BufferedMutations(Vec<BufferedMutate>);
 
 impl BufferedMutations {
-    fn clear(&mut self) {
-        self.0.clear();
-    }
-
     /// Inserts a new buffered message, maintaining sorting by their message tick in descending order.
     fn insert(&mut self, mutate: BufferedMutate) {
-        let index = self
-            .0
-            .partition_point(|other| mutate.message_tick.is_older(other.message_tick));
+        let index = self.partition_point(|other| mutate.message_tick.is_older(other.message_tick));
         self.0.insert(index, mutate);
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -263,7 +263,7 @@ fn apply_replication(
         let mut update = buffered_updates
             .0
             .pop_front()
-            .expect("front was checked above");
+            .unwrap();
         apply_update_or_log(world, params, &mut update);
     }
 
@@ -354,18 +354,19 @@ fn receive_update_message(
         stats.bytes += message.len();
     }
 
-    let flags: UpdateFlags = postcard_utils::from_buf(&mut message)?;
+    let mut flags: UpdateFlags = postcard_utils::from_buf(&mut message)?;
     let message_tick = postcard_utils::from_buf(&mut message)?;
-    let userdata_len = if flags.contains(UpdateFlags::USERDATA) {
-        receive_userdata(&mut message)?
+    let userdata = if flags.contains(UpdateFlags::USERDATA) {
+        flags.remove(UpdateFlags::USERDATA);
+        Some(receive_userdata(&mut message)?)
     } else {
-        0
+        None
     };
 
     Ok(BufferedUpdate {
         flags,
         message_tick,
-        userdata_len,
+        userdata,
         message,
     })
 }
@@ -382,19 +383,12 @@ fn apply_update_message(
     );
     world.resource_mut::<ServerUpdateTick>().0 = update.message_tick;
 
-    if update.flags.contains(UpdateFlags::USERDATA) {
-        apply_userdata(
-            world,
-            &mut update.message,
-            update.message_tick,
-            update.userdata_len,
-        );
+    if let Some(bytes) = update.userdata.take() {
+        apply_userdata(world, update.message_tick, bytes);
     }
 
-    let mut flags = update.flags;
-    flags.remove(UpdateFlags::USERDATA);
-    let last_flag = flags.last();
-    for (_, flag) in flags.iter_names() {
+    let last_flag = update.flags.last();
+    for (_, flag) in update.flags.iter_names() {
         let array_kind = if flag != last_flag {
             ArrayKind::Sized
         } else {
@@ -462,21 +456,22 @@ fn buffer_mutate_message(
         stats.bytes += message.len();
     }
 
-    let flags: MutateFlags = postcard_utils::from_buf(&mut message)?;
+    let mut flags: MutateFlags = postcard_utils::from_buf(&mut message)?;
     let mutate_index: MutateIndex = postcard_utils::from_buf(&mut message)?;
     let update_tick = postcard_utils::from_buf(&mut message)?;
     let message_tick = postcard_utils::from_buf(&mut message)?;
-    let userdata_len = if flags.contains(MutateFlags::USERDATA) {
-        receive_userdata(&mut message)?
+    let userdata = if flags.contains(MutateFlags::USERDATA) {
+        flags.remove(MutateFlags::USERDATA);
+        Some(receive_userdata(&mut message)?)
     } else {
-        0
+        None
     };
     trace!("received mutate message for {message_tick:?}");
     buffered_mutations.insert(BufferedMutate {
         flags,
         update_tick,
         message_tick,
-        userdata_len,
+        userdata,
         message,
     });
     // An ACK means the mutation has been successfully parsed and durably retained.
@@ -497,18 +492,11 @@ fn apply_mutate_message(
         mutate.flags, mutate.message_tick
     );
 
-    if mutate.flags.contains(MutateFlags::USERDATA) {
-        apply_userdata(
-            world,
-            &mut mutate.message,
-            mutate.message_tick,
-            mutate.userdata_len,
-        );
+    if let Some(bytes) = mutate.userdata.take() {
+        apply_userdata(world, mutate.message_tick, bytes);
     }
 
-    let mut flags = mutate.flags;
-    flags.remove(MutateFlags::USERDATA);
-    for (_, flag) in flags.iter_names() {
+    for (_, flag) in mutate.flags.iter_names() {
         match flag {
             MutateFlags::MESSAGES_COUNT => {
                 confirm_mutate_tick(world, params.mutate_ticks, mutate)
@@ -740,9 +728,9 @@ fn apply_changes(
     Ok(())
 }
 
-/// Reads the userdata length while leaving its bytes at the front of the message.
-fn receive_userdata(message: &mut Bytes) -> Result<usize> {
-    let len = postcard_utils::from_buf(message)?;
+/// Splits the userdata prefix off the front of the message.
+fn receive_userdata(message: &mut Bytes) -> Result<Bytes> {
+    let len: usize = postcard_utils::from_buf(message)?;
     if len > message.len() {
         return Err(format!(
             "userdata length ({len}) exceeds remaining message length ({})",
@@ -751,57 +739,30 @@ fn receive_userdata(message: &mut Bytes) -> Result<usize> {
         .into());
     }
 
-    Ok(len)
+    Ok(message.split_to(len))
 }
 
-fn apply_userdata(world: &mut World, message: &mut Bytes, message_tick: RepliconTick, len: usize) {
-    debug_assert!(
-        len <= message.len(),
-        "buffered userdata length ({len}) should not exceed retained message length ({})",
-        message.len(),
-    );
+fn apply_userdata(world: &mut World, message_tick: RepliconTick, bytes: Bytes) {
     world.trigger(UserdataReceived {
         message_tick,
-        bytes: message.split_to(len),
+        bytes,
     });
 }
 
 fn should_apply_update(world: &World, update: &BufferedUpdate) -> bool {
-    should_apply(
-        world,
-        ReplicationMessageKind::Update,
-        update.message_tick,
-        update.userdata(),
-    )
+    should_apply(world, update.message_tick, update.userdata.as_deref())
 }
 
 fn should_apply_mutate(world: &World, mutate: &BufferedMutate) -> bool {
-    should_apply(
-        world,
-        ReplicationMessageKind::Mutation,
-        mutate.message_tick,
-        mutate.userdata(),
-    )
+    should_apply(world, mutate.message_tick, mutate.userdata.as_deref())
 }
 
-fn should_apply(
-    world: &World,
-    kind: ReplicationMessageKind,
-    message_tick: RepliconTick,
-    userdata: Option<&[u8]>,
-) -> bool {
+fn should_apply(world: &World, message_tick: RepliconTick, userdata: Option<&[u8]>) -> bool {
     let Some(policy) = world.get_resource::<ReplicationApplyPolicy>().copied() else {
         return true;
     };
 
-    policy.decide(
-        world,
-        ReplicationMessageInfo {
-            kind,
-            message_tick,
-            userdata,
-        },
-    ) == ReplicationApplyDecision::Apply
+    policy.decide(world, message_tick, userdata)
 }
 
 fn apply_array(
@@ -1056,21 +1017,19 @@ pub enum ClientSystems {
 /// Controls when received replication messages may be applied to the client world.
 ///
 /// Insert this resource to inspect a message's tick and borrowed userdata before Replicon applies
-/// the rest of the message. Returning [`ReplicationApplyDecision::Defer`] retains the message and
-/// calls the policy again on a later run of [`ClientSystems::Receive`]. Without this resource,
-/// messages are applied immediately when their normal replication dependencies are satisfied.
+/// the rest of the message. Returning `false` buffers the message, and will only apply it when the
+/// policy returns `true`. Without this resource, messages are applied immediately.
 ///
 /// Update messages preserve their wire order: a deferred update also holds back all later updates
 /// and any mutation waiting for its tick, since [`ServerUpdateTick`] only advances on apply.
 /// Mutation messages reuse Replicon's existing mutation buffer. They are acknowledged after being
 /// parsed and retained, so an acknowledgment can precede application.
-///
-/// The userdata slice passed to the policy borrows the received [`Bytes`] and is not copied.
-/// Buffering is unbounded while connected: deferred messages are never evicted because acknowledged
-/// mutations can no longer be reconstructed by the server. The policy should therefore eventually
-/// return [`ReplicationApplyDecision::Apply`]; disconnecting clears all deferred messages.
+
 #[derive(Resource, Clone, Copy)]
 pub struct ReplicationApplyPolicy(ReplicationApplyFn);
+
+/// Borrowed bytes of user-defined data sent from the server.
+pub type UserDataBytes<'a> = &'a [u8];
 
 impl ReplicationApplyPolicy {
     /// Creates a policy from the given function.
@@ -1078,45 +1037,26 @@ impl ReplicationApplyPolicy {
         Self(policy)
     }
 
-    fn decide(self, world: &World, message: ReplicationMessageInfo) -> ReplicationApplyDecision {
-        (self.0)(world, message)
+    fn decide(
+        self,
+        world: &World,
+        message_tick: RepliconTick,
+        userdata: Option<UserDataBytes>,
+    ) -> bool {
+        (self.0)(world, message_tick, userdata)
     }
 }
 
 /// Function used by [`ReplicationApplyPolicy`].
 ///
+/// Takes the tick serialized in the message envelope and the raw userdata bytes,
+/// if the server attached any to this message.
+///
+/// Returns `true` to apply the message during the current receive system, `false` to retain
+/// it and ask the policy again during a later receive system.
+///
 /// State needed by the policy can be stored in resources and read from `world`.
-pub type ReplicationApplyFn =
-    for<'a> fn(&World, ReplicationMessageInfo<'a>) -> ReplicationApplyDecision;
-
-/// Result returned by [`ReplicationApplyPolicy`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ReplicationApplyDecision {
-    /// Apply the message during the current receive pass.
-    Apply,
-    /// Retain the message and ask the policy again during a later receive pass.
-    Defer,
-}
-
-/// Borrowed metadata for a received replication message.
-#[derive(Debug, Clone, Copy)]
-pub struct ReplicationMessageInfo<'a> {
-    /// Channel-level kind of replication message.
-    pub kind: ReplicationMessageKind,
-    /// Replicon tick serialized in the message envelope.
-    pub message_tick: RepliconTick,
-    /// Raw user-defined bytes, if the server attached any to this message.
-    pub userdata: Option<&'a [u8]>,
-}
-
-/// Channel-level kind of a received replication message.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ReplicationMessageKind {
-    /// Reliable, ordered update containing insertions, removals, spawns, or despawns.
-    Update,
-    /// Unordered mutation message.
-    Mutation,
-}
+pub type ReplicationApplyFn = for<'a> fn(&World, RepliconTick, Option<UserDataBytes<'a>>) -> bool;
 
 /// Last applied tick for update messages from the server.
 ///
@@ -1139,24 +1079,13 @@ impl BufferedUpdates {
 
 /// Partially-deserialized update message waiting for the user policy.
 struct BufferedUpdate {
+    /// Sections remaining in [`Self::message`].
     flags: UpdateFlags,
     message_tick: RepliconTick,
-    userdata_len: usize,
+    /// Userdata split off the front of the received message, if present.
+    userdata: Option<Bytes>,
+    /// Message bytes after the envelope (flags, tick and userdata) has been consumed.
     message: Bytes,
-}
-
-impl BufferedUpdate {
-    fn userdata(&self) -> Option<&[u8]> {
-        self.flags.contains(UpdateFlags::USERDATA).then(|| {
-            debug_assert!(
-                self.userdata_len <= self.message.len(),
-                "buffered userdata length should not exceed retained message length",
-            );
-            self.message
-                .get(..self.userdata_len)
-                .expect("buffered userdata length should not exceed retained message length")
-        })
-    }
 }
 
 /// Cached buffered mutate messages, used to synchronize mutations with update messages.
@@ -1190,25 +1119,11 @@ pub(super) struct BufferedMutate {
     /// The tick this mutations corresponds to.
     message_tick: RepliconTick,
 
-    /// Length of userdata stored at the beginning of `message`.
-    userdata_len: usize,
+    /// Userdata split off the front of the received message, if present.
+    userdata: Option<Bytes>,
 
-    /// Mutations data.
+    /// Message bytes after the envelope (flags, indices, ticks and userdata) has been consumed.
     message: Bytes,
-}
-
-impl BufferedMutate {
-    fn userdata(&self) -> Option<&[u8]> {
-        self.flags.contains(MutateFlags::USERDATA).then(|| {
-            debug_assert!(
-                self.userdata_len <= self.message.len(),
-                "buffered userdata length should not exceed retained message length",
-            );
-            self.message
-                .get(..self.userdata_len)
-                .expect("buffered userdata length should not exceed retained message length")
-        })
-    }
 }
 
 /// Replication stats during message processing.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1070,10 +1070,14 @@ struct BufferedUpdates(VecDeque<BufferedUpdate>);
 struct BufferedUpdate {
     /// Sections remaining in [`Self::message`].
     flags: UpdateFlags,
+
+    /// Tick associated with the message.
     message_tick: RepliconTick,
+
     /// Userdata split off the front of the received message, if present.
     userdata: Option<Bytes>,
-    /// Message bytes after the envelope (flags, tick and userdata) has been consumed.
+
+    /// Remaining unparsed message bytes after the buffered metadata.
     message: Bytes,
 }
 
@@ -1105,7 +1109,7 @@ pub(super) struct BufferedMutate {
     /// Userdata split off the front of the received message, if present.
     userdata: Option<Bytes>,
 
-    /// Message bytes after the envelope (flags, indices, ticks and userdata) has been consumed.
+    /// Remaining unparsed message bytes after the buffered metadata.
     message: Bytes,
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -385,7 +385,10 @@ fn apply_update_message(
                     .userdata
                     .take()
                     .expect("userdata should be extracted while buffering the message");
-                apply_userdata(world, update.message_tick, bytes);
+                world.trigger(UserdataReceived {
+                    message_tick: update.message_tick,
+                    bytes,
+                });
             }
             UpdateFlags::MAPPINGS => {
                 let len = apply_array(array_kind, &mut update.message, |message| {
@@ -490,7 +493,10 @@ fn apply_mutate_message(
                     .userdata
                     .take()
                     .expect("userdata should be extracted while buffering the message");
-                apply_userdata(world, mutate.message_tick, bytes);
+                world.trigger(UserdataReceived {
+                    message_tick: mutate.message_tick,
+                    bytes,
+                });
             }
             MutateFlags::MESSAGES_COUNT => {
                 confirm_mutate_tick(world, params.mutate_ticks, mutate)
@@ -734,13 +740,6 @@ fn read_userdata(message: &mut Bytes) -> Result<Bytes> {
     }
 
     Ok(message.split_to(len))
-}
-
-fn apply_userdata(world: &mut World, message_tick: RepliconTick, bytes: Bytes) {
-    world.trigger(UserdataReceived {
-        message_tick,
-        bytes,
-    });
 }
 
 fn should_apply_update(world: &mut World, update: &BufferedUpdate) -> bool {

--- a/src/client.rs
+++ b/src/client.rs
@@ -118,6 +118,8 @@ impl Plugin for ClientPlugin {
 /// Mutate messages are sent over [`ServerChannel::Mutations`], which means they may appear
 /// ahead-of or behind update messages from the same server tick. A mutation will only be applied if its
 /// update tick has already appeared in an update message, otherwise it will be buffered while waiting.
+/// Since a deferred update does not advance [`ServerUpdateTick`], mutations waiting for its tick stay
+/// buffered as well, even if the user policy would otherwise apply them.
 /// Since component mutations can arrive in any order, they will only be applied if they correspond to a more
 /// recent server tick than the last acked server tick for each entity.
 ///
@@ -250,6 +252,9 @@ fn apply_replication(
     buffered_mutations: &mut BufferedMutations,
 ) {
     // Update messages are ordered, so a deferred update blocks all later ones.
+    // It also stalls `ServerUpdateTick`, which holds back mutations waiting for a
+    // newer update tick. This is intended: a mutation can only be applied after
+    // the updates for ticks before it have been applied.
     while buffered_updates
         .0
         .front()
@@ -750,6 +755,11 @@ fn receive_userdata(message: &mut Bytes) -> Result<usize> {
 }
 
 fn apply_userdata(world: &mut World, message: &mut Bytes, message_tick: RepliconTick, len: usize) {
+    debug_assert!(
+        len <= message.len(),
+        "buffered userdata length ({len}) should not exceed retained message length ({})",
+        message.len(),
+    );
     world.trigger(UserdataReceived {
         message_tick,
         bytes: message.split_to(len),
@@ -1050,12 +1060,13 @@ pub enum ClientSystems {
 /// calls the policy again on a later run of [`ClientSystems::Receive`]. Without this resource,
 /// messages are applied immediately when their normal replication dependencies are satisfied.
 ///
-/// Update messages preserve their wire order: a deferred update also holds back all later updates.
+/// Update messages preserve their wire order: a deferred update also holds back all later updates
+/// and any mutation waiting for its tick, since [`ServerUpdateTick`] only advances on apply.
 /// Mutation messages reuse Replicon's existing mutation buffer. They are acknowledged after being
 /// parsed and retained, so an acknowledgment can precede application.
 ///
 /// The userdata slice passed to the policy borrows the received [`Bytes`] and is not copied.
-/// Deferred messages are never evicted while the connection remains active because acknowledged
+/// Buffering is unbounded while connected: deferred messages are never evicted because acknowledged
 /// mutations can no longer be reconstructed by the server. The policy should therefore eventually
 /// return [`ReplicationApplyDecision::Apply`]; disconnecting clears all deferred messages.
 #[derive(Resource, Clone, Copy)]
@@ -1136,9 +1147,15 @@ struct BufferedUpdate {
 
 impl BufferedUpdate {
     fn userdata(&self) -> Option<&[u8]> {
-        self.flags
-            .contains(UpdateFlags::USERDATA)
-            .then(|| &self.message[..self.userdata_len])
+        self.flags.contains(UpdateFlags::USERDATA).then(|| {
+            debug_assert!(
+                self.userdata_len <= self.message.len(),
+                "buffered userdata length should not exceed retained message length",
+            );
+            self.message
+                .get(..self.userdata_len)
+                .expect("buffered userdata length should not exceed retained message length")
+        })
     }
 }
 
@@ -1182,9 +1199,15 @@ pub(super) struct BufferedMutate {
 
 impl BufferedMutate {
     fn userdata(&self) -> Option<&[u8]> {
-        self.flags
-            .contains(MutateFlags::USERDATA)
-            .then(|| &self.message[..self.userdata_len])
+        self.flags.contains(MutateFlags::USERDATA).then(|| {
+            debug_assert!(
+                self.userdata_len <= self.message.len(),
+                "buffered userdata length should not exceed retained message length",
+            );
+            self.message
+                .get(..self.userdata_len)
+                .expect("buffered userdata length should not exceed retained message length")
+        })
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -119,7 +119,7 @@ impl Plugin for ClientPlugin {
 /// ahead-of or behind update messages from the same server tick. A mutation will only be applied if its
 /// update tick has already appeared in an update message, otherwise it will be buffered while waiting.
 /// Since a deferred update does not advance [`ServerUpdateTick`], mutations waiting for its tick stay
-/// buffered as well, even if the user policy would otherwise apply them.
+/// buffered as well, even if [`ShouldApplyReplication`] observers would otherwise apply them.
 /// Since component mutations can arrive in any order, they will only be applied if they correspond to a more
 /// recent server tick than the last acked server tick for each entity.
 ///
@@ -468,7 +468,7 @@ fn buffer_mutate_message(
         message,
     });
     // An ACK means the mutation has been successfully parsed and durably retained.
-    // Application can happen later when both its update and the user policy are ready.
+    // Application can happen later when both its update and `ShouldApplyReplication` observers are ready.
     postcard_utils::to_extend_mut(&mutate_index, acks)?;
 
     Ok(())
@@ -745,20 +745,22 @@ fn apply_userdata(world: &mut World, message_tick: RepliconTick, bytes: Bytes) {
     });
 }
 
-fn should_apply_update(world: &World, update: &BufferedUpdate) -> bool {
-    should_apply(world, update.message_tick, update.userdata.as_deref())
+fn should_apply_update(world: &mut World, update: &BufferedUpdate) -> bool {
+    should_apply(world, update.message_tick, update.userdata.as_ref())
 }
 
-fn should_apply_mutate(world: &World, mutate: &BufferedMutate) -> bool {
-    should_apply(world, mutate.message_tick, mutate.userdata.as_deref())
+fn should_apply_mutate(world: &mut World, mutate: &BufferedMutate) -> bool {
+    should_apply(world, mutate.message_tick, mutate.userdata.as_ref())
 }
 
-fn should_apply(world: &World, message_tick: RepliconTick, userdata: Option<&[u8]>) -> bool {
-    let Some(policy) = world.get_resource::<ReplicationApplyPolicy>().copied() else {
-        return true;
+fn should_apply(world: &mut World, message_tick: RepliconTick, userdata: Option<&Bytes>) -> bool {
+    let mut event = ShouldApplyReplication {
+        message_tick,
+        userdata: userdata.cloned(),
+        should_apply: true,
     };
-
-    policy.decide(world, message_tick, userdata)
+    world.trigger_ref(&mut event);
+    event.should_apply
 }
 
 fn apply_array(
@@ -1010,49 +1012,47 @@ pub enum ClientSystems {
     Reset,
 }
 
-/// Controls when received replication messages may be applied to the client world.
+/// Triggered on the client before applying a received replication message.
 ///
-/// Insert this resource to inspect a message's tick and borrowed userdata before Replicon applies
-/// the rest of the message. Returning `false` buffers the message, and will only apply it when the
-/// policy returns `true`. Without this resource, messages are applied immediately.
+/// Observe this event to inspect a message's tick and userdata before Replicon applies
+/// the rest of the message. Set [`Self::should_apply`] to `false` to buffer the message;
+/// it will be re-triggered on later receives until an observer leaves it as `true`.
+/// If it is not set to false, messages will be applied immediately.
 ///
 /// Update messages preserve their wire order: a deferred update also holds back all later updates
 /// and any mutation waiting for its tick, since [`ServerUpdateTick`] only advances on apply.
 /// Mutation messages reuse Replicon's existing mutation buffer. They are acknowledged after being
 /// parsed and retained, so an acknowledgment can precede application.
-
-#[derive(Resource, Clone, Copy)]
-pub struct ReplicationApplyPolicy(ReplicationApplyFn);
-
-/// Borrowed bytes of user-defined data sent from the server.
-pub type UserDataBytes<'a> = &'a [u8];
-
-impl ReplicationApplyPolicy {
-    /// Creates a policy from the given function.
-    pub const fn new(policy: ReplicationApplyFn) -> Self {
-        Self(policy)
-    }
-
-    fn decide(
-        self,
-        world: &World,
-        message_tick: RepliconTick,
-        userdata: Option<UserDataBytes>,
-    ) -> bool {
-        (self.0)(world, message_tick, userdata)
-    }
+///
+/// # Example
+///
+/// Defer messages carrying userdata greater than a threshold:
+///
+/// ```
+/// # use bevy::prelude::*;
+/// # use bevy_replicon::{client::ShouldApplyReplication, prelude::*};
+/// #[derive(Resource, Default)]
+/// struct Ready(u32);
+///
+/// fn defer_large_userdata(mut trigger: On<ShouldApplyReplication>, ready: Res<Ready>) {
+///     let Some(userdata) = trigger.userdata.as_ref() else {
+///         return;
+///     };
+///     let value = u32::from_le_bytes(userdata.as_ref().try_into().unwrap());
+///     if value > ready.0 {
+///         trigger.should_apply = false;
+///     }
+/// }
+/// ```
+#[derive(Event, Debug, Clone)]
+pub struct ShouldApplyReplication {
+    /// Tick serialized in the message envelope.
+    pub message_tick: RepliconTick,
+    /// Userdata split off the front of the message, if the server attached any.
+    pub userdata: Option<Bytes>,
+    /// Whether to apply the message during the current receive. Set to `false` to defer it.
+    pub should_apply: bool,
 }
-
-/// Function used by [`ReplicationApplyPolicy`].
-///
-/// Takes the tick serialized in the message envelope and the raw userdata bytes,
-/// if the server attached any to this message.
-///
-/// Returns `true` to apply the message during the current receive system, `false` to retain
-/// it and ask the policy again during a later receive system.
-///
-/// State needed by the policy can be stored in resources and read from `world`.
-pub type ReplicationApplyFn = for<'a> fn(&World, RepliconTick, Option<UserDataBytes<'a>>) -> bool;
 
 /// Last applied tick for update messages from the server.
 ///
@@ -1063,11 +1063,11 @@ pub type ReplicationApplyFn = for<'a> fn(&World, RepliconTick, Option<UserDataBy
 #[derive(Resource, Deref, Default, Reflect, Debug, Clone, Copy)]
 pub struct ServerUpdateTick(RepliconTick);
 
-/// Cached ordered update messages deferred by [`ReplicationApplyPolicy`].
+/// Cached ordered update messages deferred by [`ShouldApplyReplication`] observers.
 #[derive(Resource, Default, Deref, DerefMut)]
 struct BufferedUpdates(VecDeque<BufferedUpdate>);
 
-/// Partially-deserialized update message waiting for the user policy.
+/// Partially-deserialized update message waiting for [`ShouldApplyReplication`] observers to apply it.
 struct BufferedUpdate {
     /// Sections remaining in [`Self::message`].
     flags: UpdateFlags,

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,6 +4,8 @@ pub mod diagnostics;
 pub mod message;
 pub mod server_mutate_ticks;
 
+use alloc::collections::VecDeque;
+
 use bevy::prelude::*;
 use bytes::{Buf, Bytes};
 use log::{Level, debug, error, log_enabled, trace};
@@ -43,6 +45,7 @@ impl Plugin for ClientPlugin {
             .init_resource::<ServerEntityMap>()
             .init_resource::<ServerUpdateTick>()
             .init_resource::<ServerMutateTicks>()
+            .init_resource::<BufferedUpdates>()
             .init_resource::<BufferedMutations>()
             .add_message::<EntityReplicated>()
             .add_message::<MutateTickReceived>()
@@ -120,7 +123,9 @@ impl Plugin for ClientPlugin {
 ///
 /// Buffered mutate messages are processed last.
 ///
-/// Acknowledgments for received mutate messages are sent back to the server.
+/// Acknowledgments for accepted mutate messages are sent back to the server after they are
+/// successfully parsed and retained. An acknowledgment therefore does not imply that a mutation
+/// has already been applied.
 ///
 /// See also [`ReplicationMessages`](crate::server::replication_messages::ReplicationMessages).
 pub(super) fn receive_replication(
@@ -136,6 +141,7 @@ pub(super) fn receive_replication(
     let mut signature_map = world.remove_resource::<SignatureMap>().unwrap();
     let mut storage = world.remove_resource::<ReplicationStorage>().unwrap();
     let mut mutate_ticks = world.remove_resource::<ServerMutateTicks>().unwrap();
+    let mut buffered_updates = world.remove_resource::<BufferedUpdates>().unwrap();
     let mut buffered_mutations = world.remove_resource::<BufferedMutations>().unwrap();
     let receive_markers = world.remove_resource::<ReceiveMarkers>().unwrap();
     let registry = world.remove_resource::<ReplicationRegistry>().unwrap();
@@ -161,7 +167,13 @@ pub(super) fn receive_replication(
         type_registry: &type_registry,
     };
 
-    apply_replication(world, &mut params, &mut messages, &mut buffered_mutations);
+    apply_replication(
+        world,
+        &mut params,
+        &mut messages,
+        &mut buffered_updates,
+        &mut buffered_mutations,
+    );
 
     if let Some(stats) = stats {
         world.insert_resource(stats);
@@ -172,6 +184,7 @@ pub(super) fn receive_replication(
     world.insert_resource(signature_map);
     world.insert_resource(storage);
     world.insert_resource(mutate_ticks);
+    world.insert_resource(buffered_updates);
     world.insert_resource(buffered_mutations);
     world.insert_resource(receive_markers);
     world.insert_resource(registry);
@@ -196,6 +209,7 @@ fn reset(
     mut stats: ResMut<ClientStats>,
     mut update_tick: ResMut<ServerUpdateTick>,
     mut entity_map: ResMut<ServerEntityMap>,
+    mut buffered_updates: ResMut<BufferedUpdates>,
     mut buffered_mutations: ResMut<BufferedMutations>,
     mutate_ticks: Option<ResMut<ServerMutateTicks>>,
     replication_stats: Option<ResMut<ClientReplicationStats>>,
@@ -204,6 +218,7 @@ fn reset(
     *stats = Default::default();
     *update_tick = Default::default();
     entity_map.clear();
+    buffered_updates.clear();
     buffered_mutations.clear();
     if let Some(mut mutate_ticks) = mutate_ticks {
         mutate_ticks.clear();
@@ -231,15 +246,38 @@ fn apply_replication(
     world: &mut World,
     params: &mut ReceiveParams,
     messages: &mut ClientMessages,
+    buffered_updates: &mut BufferedUpdates,
     buffered_mutations: &mut BufferedMutations,
 ) {
-    for mut message in messages.drain_received(ServerChannel::Updates) {
-        if let Err(e) = apply_update_message(world, params, &mut message) {
-            error!("unable to apply update message: {e}");
+    // Update messages are ordered, so a deferred update blocks all later ones.
+    while buffered_updates
+        .0
+        .front()
+        .is_some_and(|update| should_apply_update(world, update))
+    {
+        let mut update = buffered_updates
+            .0
+            .pop_front()
+            .expect("front was checked above");
+        apply_update_or_log(world, params, &mut update);
+    }
 
-            // SAFETY: components in the scratch were pushed using this world.
-            unsafe { params.scratch.manual_drop(world.components()) };
-            params.entity_buffer.free(world);
+    for message in messages.drain_received(ServerChannel::Updates) {
+        let mut update = match receive_update_message(params, message) {
+            Ok(update) => update,
+            Err(e) => {
+                error!("unable to receive update message: {e}");
+                continue;
+            }
+        };
+
+        // The common case stays allocation-free: apply directly unless this update
+        // or an earlier ordered update needs to wait.
+        if buffered_updates.0.is_empty() && should_apply_update(world, &update) {
+            apply_update_or_log(world, params, &mut update);
+        } else {
+            trace!("buffering update message for {:?}", update.message_tick);
+            buffered_updates.0.push_back(update);
         }
     }
 
@@ -257,11 +295,17 @@ fn apply_replication(
                 error!("unable to buffer mutate message: {e}");
             }
         }
-        messages.send(ClientChannel::MutationAcks, acks);
+        if !acks.is_empty() {
+            messages.send(ClientChannel::MutationAcks, acks);
+        }
     }
 
     buffered_mutations.0.retain_mut(|mutate| {
         if mutate.update_tick.is_newer(*update_tick) {
+            return true;
+        }
+
+        if !should_apply_mutate(world, mutate) {
             return true;
         }
 
@@ -280,24 +324,70 @@ fn apply_replication(
     });
 }
 
-/// Reads and applies an update message.
+fn apply_update_or_log(world: &mut World, params: &mut ReceiveParams, update: &mut BufferedUpdate) {
+    if let Err(e) = apply_update_message(world, params, update) {
+        error!(
+            "unable to apply update message for tick `{:?}`: {e}",
+            update.message_tick
+        );
+
+        // SAFETY: components in the scratch were pushed using this world.
+        unsafe { params.scratch.manual_drop(world.components()) };
+        params.entity_buffer.free(world);
+    }
+}
+
+/// Partially deserializes a received update message.
 ///
 /// For details see [`replication_messages`](crate::server::replication_messages).
-fn apply_update_message(
-    world: &mut World,
+fn receive_update_message(
     params: &mut ReceiveParams,
-    message: &mut Bytes,
-) -> Result<()> {
+    mut message: Bytes,
+) -> Result<BufferedUpdate> {
     if let Some(stats) = &mut params.stats {
         stats.messages += 1;
         stats.bytes += message.len();
     }
 
-    let flags: UpdateFlags = postcard_utils::from_buf(message)?;
-    let message_tick = postcard_utils::from_buf(message)?;
-    trace!("applying update message with `{flags:?}` for {message_tick:?}");
-    world.resource_mut::<ServerUpdateTick>().0 = message_tick;
+    let flags: UpdateFlags = postcard_utils::from_buf(&mut message)?;
+    let message_tick = postcard_utils::from_buf(&mut message)?;
+    let userdata_len = if flags.contains(UpdateFlags::USERDATA) {
+        receive_userdata(&mut message)?
+    } else {
+        0
+    };
 
+    Ok(BufferedUpdate {
+        flags,
+        message_tick,
+        userdata_len,
+        message,
+    })
+}
+
+/// Applies a partially deserialized update message.
+fn apply_update_message(
+    world: &mut World,
+    params: &mut ReceiveParams,
+    update: &mut BufferedUpdate,
+) -> Result<()> {
+    trace!(
+        "applying update message with `{:?}` for {:?}",
+        update.flags, update.message_tick
+    );
+    world.resource_mut::<ServerUpdateTick>().0 = update.message_tick;
+
+    if update.flags.contains(UpdateFlags::USERDATA) {
+        apply_userdata(
+            world,
+            &mut update.message,
+            update.message_tick,
+            update.userdata_len,
+        );
+    }
+
+    let mut flags = update.flags;
+    flags.remove(UpdateFlags::USERDATA);
     let last_flag = flags.last();
     for (_, flag) in flags.iter_names() {
         let array_kind = if flag != last_flag {
@@ -307,12 +397,8 @@ fn apply_update_message(
         };
 
         match flag {
-            UpdateFlags::USERDATA => {
-                process_userdata(world, message, message_tick)
-                    .map_err(|e| format!("unable to process userdata: {e}"))?;
-            }
             UpdateFlags::MAPPINGS => {
-                let len = apply_array(array_kind, message, |message| {
+                let len = apply_array(array_kind, &mut update.message, |message| {
                     apply_entity_mapping(world, params, message)
                 })
                 .map_err(|e| format!("unable to apply mappings: {e}"))?;
@@ -321,8 +407,8 @@ fn apply_update_message(
                 }
             }
             UpdateFlags::DESPAWNS => {
-                let len = apply_array(array_kind, message, |message| {
-                    apply_despawn(world, params, message, message_tick)
+                let len = apply_array(array_kind, &mut update.message, |message| {
+                    apply_despawn(world, params, message, update.message_tick)
                 })
                 .map_err(|e| format!("unable to apply despawns: {e}"))?;
                 if let Some(stats) = &mut params.stats {
@@ -330,8 +416,8 @@ fn apply_update_message(
                 }
             }
             UpdateFlags::REMOVALS => {
-                let len = apply_array(array_kind, message, |message| {
-                    apply_removals(world, params, message, message_tick)
+                let len = apply_array(array_kind, &mut update.message, |message| {
+                    apply_removals(world, params, message, update.message_tick)
                 })
                 .map_err(|e| format!("unable to apply removals: {e}"))?;
                 if let Some(stats) = &mut params.stats {
@@ -340,8 +426,8 @@ fn apply_update_message(
             }
             UpdateFlags::CHANGES => {
                 debug_assert_eq!(array_kind, ArrayKind::Dynamic);
-                let len = apply_array(array_kind, message, |message| {
-                    apply_changes(world, params, message, message_tick)
+                let len = apply_array(array_kind, &mut update.message, |message| {
+                    apply_changes(world, params, message, update.message_tick)
                 })
                 .map_err(|e| format!("unable to apply changes: {e}"))?;
                 if let Some(stats) = &mut params.stats {
@@ -373,17 +459,24 @@ fn buffer_mutate_message(
 
     let flags: MutateFlags = postcard_utils::from_buf(&mut message)?;
     let mutate_index: MutateIndex = postcard_utils::from_buf(&mut message)?;
-    postcard_utils::to_extend_mut(&mutate_index, acks)?;
-
     let update_tick = postcard_utils::from_buf(&mut message)?;
     let message_tick = postcard_utils::from_buf(&mut message)?;
+    let userdata_len = if flags.contains(MutateFlags::USERDATA) {
+        receive_userdata(&mut message)?
+    } else {
+        0
+    };
     trace!("received mutate message for {message_tick:?}");
     buffered_mutations.insert(BufferedMutate {
         flags,
         update_tick,
         message_tick,
+        userdata_len,
         message,
     });
+    // An ACK means the mutation has been successfully parsed and durably retained.
+    // Application can happen later when both its update and the user policy are ready.
+    postcard_utils::to_extend_mut(&mutate_index, acks)?;
 
     Ok(())
 }
@@ -399,12 +492,19 @@ fn apply_mutate_message(
         mutate.flags, mutate.message_tick
     );
 
-    for (_, flag) in mutate.flags.iter_names() {
+    if mutate.flags.contains(MutateFlags::USERDATA) {
+        apply_userdata(
+            world,
+            &mut mutate.message,
+            mutate.message_tick,
+            mutate.userdata_len,
+        );
+    }
+
+    let mut flags = mutate.flags;
+    flags.remove(MutateFlags::USERDATA);
+    for (_, flag) in flags.iter_names() {
         match flag {
-            MutateFlags::USERDATA => {
-                process_userdata(world, &mut mutate.message, mutate.message_tick)
-                    .map_err(|e| format!("unable to apply userdata: {e}"))?;
-            }
             MutateFlags::MESSAGES_COUNT => {
                 confirm_mutate_tick(world, params.mutate_ticks, mutate)
                     .map_err(|e| format!("unable to confirm mutate tick: {e}"))?;
@@ -635,11 +735,8 @@ fn apply_changes(
     Ok(())
 }
 
-fn process_userdata(
-    world: &mut World,
-    message: &mut Bytes,
-    message_tick: RepliconTick,
-) -> Result<()> {
+/// Reads the userdata length while leaving its bytes at the front of the message.
+fn receive_userdata(message: &mut Bytes) -> Result<usize> {
     let len = postcard_utils::from_buf(message)?;
     if len > message.len() {
         return Err(format!(
@@ -648,12 +745,53 @@ fn process_userdata(
         )
         .into());
     }
+
+    Ok(len)
+}
+
+fn apply_userdata(world: &mut World, message: &mut Bytes, message_tick: RepliconTick, len: usize) {
     world.trigger(UserdataReceived {
         message_tick,
         bytes: message.split_to(len),
     });
+}
 
-    Ok(())
+fn should_apply_update(world: &World, update: &BufferedUpdate) -> bool {
+    should_apply(
+        world,
+        ReplicationMessageKind::Update,
+        update.message_tick,
+        update.userdata(),
+    )
+}
+
+fn should_apply_mutate(world: &World, mutate: &BufferedMutate) -> bool {
+    should_apply(
+        world,
+        ReplicationMessageKind::Mutation,
+        mutate.message_tick,
+        mutate.userdata(),
+    )
+}
+
+fn should_apply(
+    world: &World,
+    kind: ReplicationMessageKind,
+    message_tick: RepliconTick,
+    userdata: Option<&[u8]>,
+) -> bool {
+    let Some(policy) = world.get_resource::<ReplicationApplyPolicy>().copied() else {
+        return true;
+    };
+
+    policy.decide(
+        world,
+        ReplicationMessageInfo {
+            kind,
+            message_tick,
+            userdata,
+        },
+    ) == ReplicationApplyDecision::Apply
 }
 
 fn apply_array(
@@ -905,14 +1043,104 @@ pub enum ClientSystems {
     Reset,
 }
 
-/// Last received tick for update messages from the server.
+/// Controls when received replication messages may be applied to the client world.
+///
+/// Insert this resource to inspect a message's tick and borrowed userdata before Replicon applies
+/// the rest of the message. Returning [`ReplicationApplyDecision::Defer`] retains the message and
+/// calls the policy again on a later run of [`ClientSystems::Receive`]. Without this resource,
+/// messages are applied immediately when their normal replication dependencies are satisfied.
+///
+/// Update messages preserve their wire order: a deferred update also holds back all later updates.
+/// Mutation messages reuse Replicon's existing mutation buffer. They are acknowledged after being
+/// parsed and retained, so an acknowledgment can precede application.
+///
+/// The userdata slice passed to the policy borrows the received [`Bytes`] and is not copied.
+/// Deferred messages are never evicted while the connection remains active because acknowledged
+/// mutations can no longer be reconstructed by the server. The policy should therefore eventually
+/// return [`ReplicationApplyDecision::Apply`]; disconnecting clears all deferred messages.
+#[derive(Resource, Clone, Copy)]
+pub struct ReplicationApplyPolicy(ReplicationApplyFn);
+
+impl ReplicationApplyPolicy {
+    /// Creates a policy from the given function.
+    pub const fn new(policy: ReplicationApplyFn) -> Self {
+        Self(policy)
+    }
+
+    fn decide(self, world: &World, message: ReplicationMessageInfo) -> ReplicationApplyDecision {
+        (self.0)(world, message)
+    }
+}
+
+/// Function used by [`ReplicationApplyPolicy`].
+///
+/// State needed by the policy can be stored in resources and read from `world`.
+pub type ReplicationApplyFn =
+    for<'a> fn(&World, ReplicationMessageInfo<'a>) -> ReplicationApplyDecision;
+
+/// Result returned by [`ReplicationApplyPolicy`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplicationApplyDecision {
+    /// Apply the message during the current receive pass.
+    Apply,
+    /// Retain the message and ask the policy again during a later receive pass.
+    Defer,
+}
+
+/// Borrowed metadata for a received replication message.
+#[derive(Debug, Clone, Copy)]
+pub struct ReplicationMessageInfo<'a> {
+    /// Channel-level kind of replication message.
+    pub kind: ReplicationMessageKind,
+    /// Replicon tick serialized in the message envelope.
+    pub message_tick: RepliconTick,
+    /// Raw user-defined bytes, if the server attached any to this message.
+    pub userdata: Option<&'a [u8]>,
+}
+
+/// Channel-level kind of a received replication message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplicationMessageKind {
+    /// Reliable, ordered update containing insertions, removals, spawns, or despawns.
+    Update,
+    /// Unordered mutation message.
+    Mutation,
+}
+
+/// Last applied tick for update messages from the server.
 ///
 /// In other words, the last [`RepliconTick`] with a removal, insertion, spawn or despawn.
-/// This value is not updated when mutation messages are received from the server.
+/// This value is not updated when mutation messages are received or applied.
 ///
 /// See also [`ServerMutateTicks`].
 #[derive(Resource, Deref, Default, Reflect, Debug, Clone, Copy)]
 pub struct ServerUpdateTick(RepliconTick);
+
+/// Cached ordered update messages deferred by [`ReplicationApplyPolicy`].
+#[derive(Resource, Default)]
+struct BufferedUpdates(VecDeque<BufferedUpdate>);
+
+impl BufferedUpdates {
+    fn clear(&mut self) {
+        self.0.clear();
+    }
+}
+
+/// Partially-deserialized update message waiting for the user policy.
+struct BufferedUpdate {
+    flags: UpdateFlags,
+    message_tick: RepliconTick,
+    userdata_len: usize,
+    message: Bytes,
+}
+
+impl BufferedUpdate {
+    fn userdata(&self) -> Option<&[u8]> {
+        self.flags
+            .contains(UpdateFlags::USERDATA)
+            .then(|| &self.message[..self.userdata_len])
+    }
+}
 
 /// Cached buffered mutate messages, used to synchronize mutations with update messages.
 #[derive(Resource, Default)]
@@ -945,8 +1173,19 @@ pub(super) struct BufferedMutate {
     /// The tick this mutations corresponds to.
     message_tick: RepliconTick,
 
+    /// Length of userdata stored at the beginning of `message`.
+    userdata_len: usize,
+
     /// Mutations data.
     message: Bytes,
+}
+
+impl BufferedMutate {
+    fn userdata(&self) -> Option<&[u8]> {
+        self.flags
+            .contains(MutateFlags::USERDATA)
+            .then(|| &self.message[..self.userdata_len])
+    }
 }
 
 /// Replication stats during message processing.
@@ -994,7 +1233,7 @@ pub struct ClientReplicationStats {
 #[reflect(Component)]
 pub struct Remote;
 
-/// Triggered when user-defined bytes are received in a replication message.
+/// Triggered when user-defined bytes are applied from a replication message.
 ///
 /// This is emitted for data sent through [`ReplicationUserdata`](crate::server::ReplicationUserdata).
 #[derive(Event)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1043,11 +1043,13 @@ pub enum ClientSystems {
 /// ```
 #[derive(Event, Debug, Clone)]
 pub struct ShouldApplyReplication {
-    /// Tick serialized in the message envelope.
+    /// Tick associated with the message.
     pub message_tick: RepliconTick,
     /// Userdata split off the front of the message, if the server attached any.
     pub userdata: Option<Bytes>,
-    /// Whether to apply the message during the current receive. Set to `false` to defer it.
+    /// Whether to apply the message during the current receive.
+    ///
+    /// You can set to `false` to defer it.
     pub should_apply: bool,
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -264,7 +264,7 @@ fn apply_replication(
     }
 
     for message in messages.drain_received(ServerChannel::Updates) {
-        let mut update = match receive_update_message(params, message) {
+        let mut update = match buffer_update_message(params, message) {
             Ok(update) => update,
             Err(e) => {
                 error!("unable to receive update message: {e}");
@@ -337,10 +337,7 @@ fn try_apply_update(world: &mut World, params: &mut ReceiveParams, update: &mut 
 /// Partially deserializes a received update message.
 ///
 /// For details see [`replication_messages`](crate::server::replication_messages).
-fn receive_update_message(
-    params: &mut ReceiveParams,
-    mut message: Bytes,
-) -> Result<BufferedUpdate> {
+fn buffer_update_message(params: &mut ReceiveParams, mut message: Bytes) -> Result<BufferedUpdate> {
     if let Some(stats) = &mut params.stats {
         stats.messages += 1;
         stats.bytes += message.len();
@@ -349,7 +346,7 @@ fn receive_update_message(
     let flags: UpdateFlags = postcard_utils::from_buf(&mut message)?;
     let message_tick = postcard_utils::from_buf(&mut message)?;
     let userdata = if flags.contains(UpdateFlags::USERDATA) {
-        Some(receive_userdata(&mut message)?)
+        Some(read_userdata(&mut message)?)
     } else {
         None
     };
@@ -455,7 +452,7 @@ fn buffer_mutate_message(
     let update_tick = postcard_utils::from_buf(&mut message)?;
     let message_tick = postcard_utils::from_buf(&mut message)?;
     let userdata = if flags.contains(MutateFlags::USERDATA) {
-        Some(receive_userdata(&mut message)?)
+        Some(read_userdata(&mut message)?)
     } else {
         None
     };
@@ -725,7 +722,7 @@ fn apply_changes(
 }
 
 /// Splits the userdata prefix off the front of the message.
-fn receive_userdata(message: &mut Bytes) -> Result<Bytes> {
+fn read_userdata(message: &mut Bytes) -> Result<Bytes> {
     let len: usize = postcard_utils::from_buf(message)?;
     if len > message.len() {
         return Err(format!(

--- a/src/client.rs
+++ b/src/client.rs
@@ -1027,7 +1027,7 @@ pub enum ClientSystems {
 ///
 /// ```
 /// # use bevy::prelude::*;
-/// # use bevy_replicon::{client::ShouldApplyReplication, prelude::*};
+/// # use bevy_replicon::prelude::*;
 /// #[derive(Resource, Default)]
 /// struct Ready(u32);
 ///

--- a/src/client.rs
+++ b/src/client.rs
@@ -321,19 +321,6 @@ fn apply_replication(
     });
 }
 
-fn try_apply_update(world: &mut World, params: &mut ReceiveParams, update: &mut BufferedUpdate) {
-    if let Err(e) = apply_update_message(world, params, update) {
-        error!(
-            "unable to apply update message for tick `{:?}`: {e}",
-            update.message_tick
-        );
-
-        // SAFETY: components in the scratch were pushed using this world.
-        unsafe { params.scratch.manual_drop(world.components()) };
-        params.entity_buffer.free(world);
-    }
-}
-
 /// Partially deserializes a received update message.
 ///
 /// For details see [`replication_messages`](crate::server::replication_messages).
@@ -357,6 +344,19 @@ fn buffer_update_message(params: &mut ReceiveParams, mut message: Bytes) -> Resu
         userdata,
         message,
     })
+}
+
+fn try_apply_update(world: &mut World, params: &mut ReceiveParams, update: &mut BufferedUpdate) {
+    if let Err(e) = apply_update_message(world, params, update) {
+        error!(
+            "unable to apply update message for tick `{:?}`: {e}",
+            update.message_tick
+        );
+
+        // SAFETY: components in the scratch were pushed using this world.
+        unsafe { params.scratch.manual_drop(world.components()) };
+        params.entity_buffer.free(world);
+    }
 }
 
 /// Applies a partially deserialized update message.

--- a/src/client.rs
+++ b/src/client.rs
@@ -384,7 +384,7 @@ fn apply_update_message(
                 let bytes = update
                     .userdata
                     .take()
-                    .expect("userdata should be present because the USERDATA flag is set");
+                    .expect("userdata should be extracted while buffering the message");
                 apply_userdata(world, update.message_tick, bytes);
             }
             UpdateFlags::MAPPINGS => {
@@ -488,7 +488,7 @@ fn apply_mutate_message(
                 let bytes = mutate
                     .userdata
                     .take()
-                    .expect("userdata should be present because the USERDATA flag is set");
+                    .expect("userdata should be extracted while buffering the message");
                 apply_userdata(world, mutate.message_tick, bytes);
             }
             MutateFlags::MESSAGES_COUNT => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -464,6 +464,7 @@ fn buffer_mutate_message(
         userdata,
         message,
     });
+
     // An ACK means the mutation has been successfully parsed and durably retained.
     // Application can happen later when both its update and `ShouldApplyReplication` observers are ready.
     postcard_utils::to_extend_mut(&mutate_index, acks)?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -260,10 +260,7 @@ fn apply_replication(
         .front()
         .is_some_and(|update| should_apply_update(world, update))
     {
-        let mut update = buffered_updates
-            .0
-            .pop_front()
-            .unwrap();
+        let mut update = buffered_updates.0.pop_front().unwrap();
         apply_update_or_log(world, params, &mut update);
     }
 

--- a/src/client/confirm_history.rs
+++ b/src/client/confirm_history.rs
@@ -6,14 +6,14 @@ use crate::prelude::*;
 
 /// Confirmed ticks from the server for an entity.
 ///
-/// For efficiency, we store only the last received tick and
-/// a bitmask indicating whether the most recent 64 ticks were received.
+/// For efficiency, we store only the last applied tick and
+/// a bitmask indicating whether the most recent 64 ticks were applied.
 ///
-/// The tick is considered confirmed when an entity receives any insertion, removal, or mutation
+/// The tick is considered confirmed when an entity applies any insertion, removal, or mutation
 /// (because entity updates are atomic). However, if there were no changes for this entity,
 /// this component will not be updated. Therefore, when the tick is not reported as confirmed, you need
 /// to check [`ServerMutateTicks::contains`](super::server_mutate_ticks::ServerMutateTicks::contains)
-/// to see whether all update messages for this tick have been received. If so, the entity is confirmed
+/// to see whether all mutate messages for this tick have been applied. If so, the entity is confirmed
 /// for this tick - there were simply no changes for it.
 ///
 /// See also [`EntityReplicated`] and the [ticks information](crate#ticks-information)
@@ -23,7 +23,7 @@ pub struct ConfirmHistory {
     /// Previously confirmed ticks, including the last tick at position 0.
     mask: u64,
 
-    /// The last received server tick for an entity.
+    /// The last applied server tick for an entity.
     last_tick: RepliconTick,
 }
 
@@ -39,19 +39,19 @@ impl ConfirmHistory {
         Self { mask: 1, last_tick }
     }
 
-    /// Returns the last received tick for an entity.
+    /// Returns the last applied tick for an entity.
     pub fn last_tick(&self) -> RepliconTick {
         self.last_tick
     }
 
-    /// Returns a mask that represents the received ticks.
+    /// Returns a mask that represents the applied ticks.
     pub fn mask(&self) -> u64 {
         self.mask
     }
 
     /// Returns `true` if this tick is confirmed for an entity.
     ///
-    /// All ticks older then 64 ticks since [`Self::last_tick`] are considered received.
+    /// All ticks older then 64 ticks since [`Self::last_tick`] are considered applied.
     pub fn contains(&self, tick: RepliconTick) -> bool {
         if tick.is_newer(self.last_tick) {
             return false;
@@ -64,7 +64,7 @@ impl ConfirmHistory {
     /// Returns `true` if any tick in the given range was confirmed for the entity with
     /// this component.
     ///
-    /// All ticks older then 64 ticks since [`Self::last_tick`] are considered received.
+    /// All ticks older then 64 ticks since [`Self::last_tick`] are considered applied.
     ///
     /// # Panics
     ///
@@ -108,7 +108,7 @@ impl ConfirmHistory {
         }
     }
 
-    /// Marks previous tick as received.
+    /// Marks a previous tick as applied.
     ///
     /// # Panics
     ///
@@ -119,7 +119,7 @@ impl ConfirmHistory {
         self.mask |= 1 << ago;
     }
 
-    /// Sets the last received tick and shifts the mask.
+    /// Sets the last applied tick and shifts the mask.
     ///
     /// # Panics
     ///
@@ -134,12 +134,12 @@ impl ConfirmHistory {
     }
 }
 
-/// A message that indicates that an entity received update for a tick.
+/// A message that indicates that an entity applied an update for a tick.
 ///
 /// See also [`ConfirmHistory`].
 #[derive(Message, Debug, Clone, Copy)]
 pub struct EntityReplicated {
-    /// Entity that received an update.
+    /// Entity that applied an update.
     pub entity: Entity,
 
     /// Message tick.

--- a/src/client/server_mutate_ticks.rs
+++ b/src/client/server_mutate_ticks.rs
@@ -9,7 +9,7 @@ use crate::prelude::*;
 ///
 /// For efficiency, we store only the last applied tick and an array indicating whether all mutate
 /// messages for the most recent 64 ticks were applied. A mutate message can be acknowledged before
-/// it is reflected here if a [`ShouldApplyReplication`](super::ShouldApplyReplication) observer defers it.
+/// it is reflected here if a [`ShouldApplyReplication`] observer defers it.
 ///
 /// See also [`MutateTickReceived`] and the [ticks information](crate#ticks-information)
 /// in the quick start guide.

--- a/src/client/server_mutate_ticks.rs
+++ b/src/client/server_mutate_ticks.rs
@@ -5,11 +5,11 @@ use log::trace;
 
 use crate::prelude::*;
 
-/// Ticks for received mutate message from server.
+/// Ticks for applied mutate messages from the server.
 ///
-/// For efficiency, we store only the last received tick and
-/// an array indicating whether all mutate messages for the most
-/// recent 64 ticks were received.
+/// For efficiency, we store only the last applied tick and an array indicating whether all mutate
+/// messages for the most recent 64 ticks were applied. A mutate message can be acknowledged before
+/// it is reflected here if [`ReplicationApplyPolicy`] defers it.
 ///
 /// See also [`MutateTickReceived`] and the [ticks information](crate#ticks-information)
 /// in the quick start guide.
@@ -17,23 +17,23 @@ use crate::prelude::*;
 pub struct ServerMutateTicks {
     ticks: VecDeque<TickMessages>,
 
-    /// The last received server tick with mutation.
+    /// The last applied server tick with mutation.
     last_tick: RepliconTick,
 
-    /// The latest server tick reported as fully received.
+    /// The latest server tick reported as fully applied.
     ///
     /// This can never go backwards, it represents a 'frontier' where the state on the
-    /// server is guaranteed to be fully received by the client.
+    /// server is guaranteed to be fully applied by the client.
     last_confirmed_tick: Option<RepliconTick>,
 }
 
 impl ServerMutateTicks {
-    /// Returns the last received tick.
+    /// Returns the last applied tick.
     pub fn last_tick(&self) -> RepliconTick {
         self.last_tick
     }
 
-    /// Returns the last tick reported as fully received.
+    /// Returns the last tick reported as fully applied.
     ///
     /// Returns `None` until a [`MutateTickReceived`] message is emitted, or after
     /// the resource is reset on disconnect.
@@ -41,12 +41,12 @@ impl ServerMutateTicks {
         self.last_confirmed_tick
     }
 
-    /// Returns a mask that represents the received ticks.
+    /// Returns a mask that represents the applied ticks.
     pub fn mask(&self) -> u64 {
         let mut bitmask = 0;
 
         for (i, tick) in self.ticks.iter().enumerate() {
-            if tick.all_received() {
+            if tick.all_applied() {
                 bitmask |= 1 << i;
             }
         }
@@ -54,9 +54,9 @@ impl ServerMutateTicks {
         bitmask
     }
 
-    /// Returns `true` if, for the given tick, all mutation messages were received.
+    /// Returns `true` if, for the given tick, all mutation messages were applied.
     ///
-    /// All ticks older than 64 ticks relative to [`Self::last_tick`] are considered received.
+    /// All ticks older than 64 ticks relative to [`Self::last_tick`] are considered applied.
     pub fn contains(&self, tick: RepliconTick) -> bool {
         if tick.is_newer(self.last_tick) {
             return false;
@@ -64,15 +64,15 @@ impl ServerMutateTicks {
 
         let ago = self.last_tick - tick;
         if let Some(tick) = self.ticks.get(ago as usize) {
-            tick.all_received()
+            tick.all_applied()
         } else {
             true
         }
     }
 
-    /// Returns `true` if, for any tick in the given range, all mutation messages were received.
+    /// Returns `true` if, for any tick in the given range, all mutation messages were applied.
     ///
-    /// All ticks older than 64 ticks relative to [`Self::last_tick`] are considered received.
+    /// All ticks older than 64 ticks relative to [`Self::last_tick`] are considered applied.
     ///
     /// # Panics
     ///
@@ -97,15 +97,13 @@ impl ServerMutateTicks {
         // array are stored in decreasing order.
         let end = (self.last_tick - start_tick) as usize;
         let start = (self.last_tick - end_tick) as usize;
-        self.ticks
-            .range(start..=end)
-            .any(|tick| tick.all_received())
+        self.ticks.range(start..=end).any(|tick| tick.all_applied())
     }
 
-    /// Confirms a message was received for a tick and initializes the number of sent
+    /// Confirms a message was applied for a tick and initializes the number of sent
     /// messages for it.
     ///
-    /// Return `true` if the number of received messages matches `messages_count`.
+    /// Return `true` if the number of applied messages matches `messages_count`.
     ///
     /// # Panics
     ///
@@ -167,16 +165,16 @@ impl Default for ServerMutateTicks {
     }
 }
 
-/// Tracker for mutable messages received for a tick.
+/// Tracker for mutate messages applied for a tick.
 #[derive(Clone, Copy, Debug, Default)]
 struct TickMessages {
     /// Number of sent messages.
     ///
-    /// If zero, we consider the tick as completely non-received.
+    /// If zero, we consider the tick as having no applied messages.
     messages_count: usize,
 
-    /// Number of received messages.
-    received: usize,
+    /// Number of applied messages.
+    applied: usize,
 }
 
 impl TickMessages {
@@ -189,24 +187,24 @@ impl TickMessages {
         );
 
         self.messages_count = messages_count;
-        self.received += 1;
+        self.applied += 1;
 
         debug_assert!(
-            self.received <= self.messages_count,
+            self.applied <= self.messages_count,
             "expected at most {} messages, but confirmed {}",
             self.messages_count,
-            self.received,
+            self.applied,
         );
 
-        self.all_received()
+        self.all_applied()
     }
 
-    fn all_received(&self) -> bool {
-        self.messages_count != 0 && self.messages_count == self.received
+    fn all_applied(&self) -> bool {
+        self.messages_count != 0 && self.messages_count == self.applied
     }
 }
 
-/// A message that indicates that all mutate messages are received for a tick.
+/// A message that indicates that all mutate messages are applied for a tick.
 ///
 /// See also [`ServerMutateTicks`].
 #[derive(Message, Debug, Clone, Copy)]

--- a/src/client/server_mutate_ticks.rs
+++ b/src/client/server_mutate_ticks.rs
@@ -9,7 +9,7 @@ use crate::prelude::*;
 ///
 /// For efficiency, we store only the last applied tick and an array indicating whether all mutate
 /// messages for the most recent 64 ticks were applied. A mutate message can be acknowledged before
-/// it is reflected here if [`ReplicationApplyPolicy`] defers it.
+/// it is reflected here if a [`ShouldApplyReplication`](super::ShouldApplyReplication) observer defers it.
 ///
 /// See also [`MutateTickReceived`] and the [ticks information](crate#ticks-information)
 /// in the quick start guide.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -649,7 +649,12 @@ with receive markers.
 ### Replication userdata
 
 It's possible to attach arbitrary bytes to replication messages by writing to the [`ReplicationUserdata`](server::ReplicationUserdata)
-resource. When the client receives a replication message containing userdata, [`UserdataReceived`](client::UserdataReceived) is triggered.
+resource. When the client applies a replication message containing userdata, [`UserdataReceived`](client::UserdataReceived) is triggered.
+
+Insert [`ReplicationApplyPolicy`] on the client to inspect the
+message tick and borrowed userdata first. The policy can defer application until an external timeline
+is ready. Update messages remain ordered, and deferred mutation messages are acknowledged once retained
+even though their world changes and application notifications happen later.
 
 ### Ticks information
 
@@ -657,18 +662,18 @@ This requires an understanding of how replication works. See the documentation o
 [`ServerChannel`](shared::backend::channels::ServerChannel) and [this section](#eventual-consistency) for more details.
 
 To get information about confirmed ticks for individual entities, we provide
-[`ConfirmHistory`](client::confirm_history::ConfirmHistory). This component is updated when any replication for its entity is received.
+[`ConfirmHistory`](client::confirm_history::ConfirmHistory). This component is updated when replication for its entity is applied.
 For convenience, we also emit the [`EntityReplicated`](client::confirm_history::EntityReplicated) to ergonomically react on it.
 
 However, an entity might not have any mutations at a given tick. You can check this by inspecting whether all mutate messages have
-been received for this tick via [`ServerMutateTicks`](client::server_mutate_ticks::ServerMutateTicks). Since this requires including
+been applied for this tick via [`ServerMutateTicks`](client::server_mutate_ticks::ServerMutateTicks). Since this requires including
 the number of mutate messages in each mutate message, you need to enable this by setting [`ServerPlugin::track_mutate_messages`].
 For convenience, we also emit the [`MutateTickReceived`](client::server_mutate_ticks::MutateTickReceived) to ergonomically react on it.
 
 So, a tick for an entity is confirmed if one of the following is true:
-- [`ConfirmHistory`](client::confirm_history::ConfirmHistory) reports that the tick is received.
-- [`ServerMutateTicks`](client::server_mutate_ticks::ServerMutateTicks) reports that for at least one of the next ticks, all update
-  messages have been received.
+- [`ConfirmHistory`](client::confirm_history::ConfirmHistory) reports that the tick is applied.
+- [`ServerMutateTicks`](client::server_mutate_ticks::ServerMutateTicks) reports that for at least one of the next ticks, all mutate
+  messages have been applied.
 
 ### Optimizing entity serialization
 
@@ -782,7 +787,9 @@ pub mod prelude {
 
     #[cfg(feature = "client")]
     pub use super::client::{
-        ClientPlugin, ClientReplicationStats, ClientSystems, Remote, message::ClientMessagePlugin,
+        ClientPlugin, ClientReplicationStats, ClientSystems, Remote, ReplicationApplyDecision,
+        ReplicationApplyFn, ReplicationApplyPolicy, ReplicationMessageInfo, ReplicationMessageKind,
+        message::ClientMessagePlugin,
     };
 
     #[cfg(feature = "server")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -651,10 +651,9 @@ with receive markers.
 It's possible to attach arbitrary bytes to replication messages by writing to the [`ReplicationUserdata`](server::ReplicationUserdata)
 resource. When the client applies a replication message containing userdata, [`UserdataReceived`](client::UserdataReceived) is triggered.
 
-Insert [`ReplicationApplyPolicy`] on the client to inspect the
-message tick and borrowed userdata first. The policy can defer application until an external timeline
-is ready. Update messages remain ordered, and deferred mutation messages are acknowledged once retained
-even though their world changes and application notifications happen later.
+Observe [`ShouldApplyReplication`] on the client to inspect the
+message tick and userdata first. Observers can set `should_apply` to `false` to defer application
+until an external timeline is ready.
 
 ### Ticks information
 
@@ -787,8 +786,8 @@ pub mod prelude {
 
     #[cfg(feature = "client")]
     pub use super::client::{
-        ClientPlugin, ClientReplicationStats, ClientSystems, Remote, ReplicationApplyFn,
-        ReplicationApplyPolicy, UserDataBytes, message::ClientMessagePlugin,
+        ClientPlugin, ClientReplicationStats, ClientSystems, Remote, ShouldApplyReplication,
+        message::ClientMessagePlugin,
     };
 
     #[cfg(feature = "server")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -787,9 +787,8 @@ pub mod prelude {
 
     #[cfg(feature = "client")]
     pub use super::client::{
-        ClientPlugin, ClientReplicationStats, ClientSystems, Remote, ReplicationApplyDecision,
-        ReplicationApplyFn, ReplicationApplyPolicy, ReplicationMessageInfo, ReplicationMessageKind,
-        message::ClientMessagePlugin,
+        ClientPlugin, ClientReplicationStats, ClientSystems, Remote, ReplicationApplyFn,
+        ReplicationApplyPolicy, UserDataBytes, message::ClientMessagePlugin,
     };
 
     #[cfg(feature = "server")]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1099,7 +1099,7 @@ struct TrackMutateMessages(bool);
 /// When this resource is non-empty, its contents are sent with every replication
 /// update and mutate message. When the client applies the message, the bytes are triggered as a
 /// [`UserdataReceived`](crate::client::UserdataReceived) before the rest of its contents. A
-/// [`ShouldApplyReplication`](crate::client::ShouldApplyReplication) observer can inspect the bytes first
+/// [`ShouldApplyReplication`] observer can inspect the bytes first
 /// and defer the entire message.
 ///
 /// This could be useful to store the game tick for prediction/interpolaton.

--- a/src/server.rs
+++ b/src/server.rs
@@ -1099,7 +1099,7 @@ struct TrackMutateMessages(bool);
 /// When this resource is non-empty, its contents are sent with every replication
 /// update and mutate message. When the client applies the message, the bytes are triggered as a
 /// [`UserdataReceived`](crate::client::UserdataReceived) before the rest of its contents. A
-/// [`ReplicationApplyPolicy`] can inspect the bytes first
+/// [`ShouldApplyReplication`](crate::client::ShouldApplyReplication) observer can inspect the bytes first
 /// and defer the entire message.
 ///
 /// This could be useful to store the game tick for prediction/interpolaton.

--- a/src/server.rs
+++ b/src/server.rs
@@ -1097,9 +1097,10 @@ struct TrackMutateMessages(bool);
 /// User-defined bytes appended to outgoing replication messages.
 ///
 /// When this resource is non-empty, its contents are sent with every replication
-/// update and mutate message. On the client, the bytes are triggered as a
-/// [`UserdataReceived`](crate::client::UserdataReceived) before the rest of
-/// the message is applied.
+/// update and mutate message. When the client applies the message, the bytes are triggered as a
+/// [`UserdataReceived`](crate::client::UserdataReceived) before the rest of its contents. A
+/// [`ReplicationApplyPolicy`] can inspect the bytes first
+/// and defer the entire message.
 ///
 /// This could be useful to store the game tick for prediction/interpolaton.
 ///

--- a/src/shared/replication/client_ticks.rs
+++ b/src/shared/replication/client_ticks.rs
@@ -25,8 +25,8 @@ pub(crate) type DiffCursors = SmallVec<[(ComponentIndex, DiffIndex); 3]>;
 pub(crate) struct ClientTicks {
     /// Last acknowledged tick for each visible entity with its components.
     ///
-    /// Used to track what the client has acknowledged as accepted and retained. With a client-side
-    /// application policy, this can be newer than the state already applied to its world.
+    /// Used to track what the client has acknowledged as accepted and retained. With client-side
+    /// deferred application, this can be newer than the state already applied to its world.
     pub(crate) entities: EntityHashMap<EntityTicks>,
 
     /// The last tick in which a replicated entity had an insertion, removal, or gained/lost a component from the

--- a/src/shared/replication/client_ticks.rs
+++ b/src/shared/replication/client_ticks.rs
@@ -25,7 +25,8 @@ pub(crate) type DiffCursors = SmallVec<[(ComponentIndex, DiffIndex); 3]>;
 pub(crate) struct ClientTicks {
     /// Last acknowledged tick for each visible entity with its components.
     ///
-    /// Used to track what the client has already received.
+    /// Used to track what the client has acknowledged as accepted and retained. With a client-side
+    /// application policy, this can be newer than the state already applied to its world.
     pub(crate) entities: EntityHashMap<EntityTicks>,
 
     /// The last tick in which a replicated entity had an insertion, removal, or gained/lost a component from the

--- a/tests/userdata.rs
+++ b/tests/userdata.rs
@@ -96,36 +96,6 @@ fn mutate_message() {
 }
 
 #[test]
-fn defer_update_message() {
-    let (mut server_app, mut client_app) = create_apps();
-    server_app.connect_client(&mut client_app);
-
-    set_userdata(&mut server_app, USERDATA);
-    server_app.world_mut().spawn((Replicated, TestComponent));
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-
-    assert_eq!(remote_count(&mut client_app), 0);
-    assert_eq!(
-        client_app.world().resource::<ReceivedUserdata>().0,
-        0,
-        "userdata should be emitted only when its message is applied"
-    );
-
-    // The observer accepts the userdata, so the update is applied.
-    client_app.world_mut().resource_mut::<ReadyUserdata>().0 = USERDATA;
-    client_app.update();
-
-    assert_eq!(remote_count(&mut client_app), 1);
-    assert_eq!(
-        client_app.world().resource::<ReceivedUserdata>().0,
-        USERDATA
-    );
-}
-
-#[test]
 fn deferred_update_blocks_later_updates() {
     let (mut server_app, mut client_app) = create_apps();
     client_app.world_mut().resource_mut::<ReadyUserdata>().0 = 1;

--- a/tests/userdata.rs
+++ b/tests/userdata.rs
@@ -98,9 +98,6 @@ fn mutate_message() {
 #[test]
 fn defer_update_message() {
     let (mut server_app, mut client_app) = create_apps();
-    client_app
-        .world_mut()
-        .insert_resource(ReplicationApplyPolicy::new(apply_when_ready));
     server_app.connect_client(&mut client_app);
 
     set_userdata(&mut server_app, USERDATA);
@@ -117,7 +114,7 @@ fn defer_update_message() {
         "userdata should be emitted only when its message is applied"
     );
 
-    // The policy accepts the userdata, so the update is applied.
+    // The observer accepts the userdata, so the update is applied.
     client_app.world_mut().resource_mut::<ReadyUserdata>().0 = USERDATA;
     client_app.update();
 
@@ -131,9 +128,6 @@ fn defer_update_message() {
 #[test]
 fn deferred_update_blocks_later_updates() {
     let (mut server_app, mut client_app) = create_apps();
-    client_app
-        .world_mut()
-        .insert_resource(ReplicationApplyPolicy::new(apply_when_ready));
     client_app.world_mut().resource_mut::<ReadyUserdata>().0 = 1;
     server_app.connect_client(&mut client_app);
 
@@ -176,9 +170,6 @@ fn deferred_update_blocks_later_updates() {
 #[test]
 fn deferred_updates_cleared_on_disconnect() {
     let (mut server_app, mut client_app) = create_apps();
-    client_app
-        .world_mut()
-        .insert_resource(ReplicationApplyPolicy::new(apply_when_ready));
     server_app.connect_client(&mut client_app);
 
     // Defer a spawn; it stays buffered and unapplied.
@@ -219,9 +210,6 @@ fn deferred_updates_cleared_on_disconnect() {
 #[test]
 fn deferred_mutation_is_acked_before_application() {
     let (mut server_app, mut client_app) = create_apps();
-    client_app
-        .world_mut()
-        .insert_resource(ReplicationApplyPolicy::new(apply_when_ready));
     server_app.connect_client(&mut client_app);
 
     let server_entity = server_app
@@ -270,9 +258,6 @@ fn deferred_mutation_is_acked_before_application() {
 #[test]
 fn deferred_update_holds_back_mutation() {
     let (mut server_app, mut client_app) = create_apps();
-    client_app
-        .world_mut()
-        .insert_resource(ReplicationApplyPolicy::new(apply_when_ready));
     client_app.world_mut().resource_mut::<ReadyUserdata>().0 = 1;
     server_app.connect_client(&mut client_app);
 
@@ -287,7 +272,7 @@ fn deferred_update_holds_back_mutation() {
     client_app.update();
     assert_eq!(remote_count(&mut client_app), 0);
 
-    // The policy accepts this mutation's userdata, but its update is still deferred,
+    // The observer accepts this mutation's userdata, but its update is still deferred,
     // so it must stay buffered until the update is applied.
     set_userdata(&mut server_app, 1);
     server_app
@@ -349,6 +334,7 @@ fn create_apps() -> (App, App) {
         .replicate::<ValueComponent>()
         .finish();
     }
+    client_app.add_observer(apply_when_ready);
 
     (server_app, client_app)
 }
@@ -359,16 +345,19 @@ fn set_userdata(app: &mut App, value: u32) {
     userdata.extend_from_slice(&value.to_le_bytes());
 }
 
-fn apply_when_ready(
-    world: &World,
-    _message_tick: RepliconTick,
-    userdata: Option<UserDataBytes>,
-) -> bool {
-    let Some(userdata) = userdata else {
-        return true;
+fn apply_when_ready(mut trigger: On<ShouldApplyReplication>, ready: Res<ReadyUserdata>) {
+    let Some(userdata) = trigger.userdata.as_ref() else {
+        return;
     };
-    let value = u32::from_le_bytes(userdata.try_into().expect("test userdata should be a u32"));
-    value <= world.resource::<ReadyUserdata>().0
+    let value = u32::from_le_bytes(
+        userdata
+            .as_ref()
+            .try_into()
+            .expect("test userdata should be a u32"),
+    );
+    if value > ready.0 {
+        trigger.should_apply = false;
+    }
 }
 
 fn remote_count(app: &mut App) -> usize {

--- a/tests/userdata.rs
+++ b/tests/userdata.rs
@@ -205,7 +205,7 @@ fn deferred_mutation() {
     client_app.update();
 
     assert_eq!(remote.iter(client_app.world()).len(), 0);
-    assert_eq!(**client_app.world().resource::<ReceivedUserdata>(), Some(0));
+    assert_eq!(**client_app.world().resource::<ReceivedUserdata>(), None);
 
     let messages = client_app.world().resource::<ClientMessages>();
     assert!(
@@ -220,7 +220,7 @@ fn deferred_mutation() {
 
     assert_eq!(
         **client_app.world().resource::<ReceivedUserdata>(),
-        Some(1),
+        Some(0),
         "messages should be applied in wire order once the update is ready"
     );
     assert_eq!(remote.iter(client_app.world()).len(), 1);

--- a/tests/userdata.rs
+++ b/tests/userdata.rs
@@ -173,6 +173,49 @@ fn deferred_update_blocks_later_updates() {
 }
 
 #[test]
+fn deferred_updates_cleared_on_disconnect() {
+    let (mut server_app, mut client_app) = create_apps();
+    client_app
+        .world_mut()
+        .insert_resource(ReplicationApplyPolicy::new(apply_when_ready));
+    server_app.connect_client(&mut client_app);
+
+    // Defer a spawn; it stays buffered and unapplied.
+    set_userdata(&mut server_app, USERDATA);
+    server_app.world_mut().spawn((Replicated, TestComponent));
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    assert_eq!(remote_count(&mut client_app), 0);
+
+    // Disconnect runs the client reset, which must drop the deferred message.
+    server_app.disconnect_client(&mut client_app);
+    assert_eq!(remote_count(&mut client_app), 0);
+
+    // Reconnect with a policy that would still defer the stale message (`USERDATA` > 1).
+    // If it survived, it would head-of-line block the fresh state. The userdata is
+    // set before the handshake so handshake updates don't re-attach the stale value.
+    client_app.world_mut().resource_mut::<ReadyUserdata>().0 = 1;
+    set_userdata(&mut server_app, 1);
+    server_app.connect_client(&mut client_app);
+    server_app.world_mut().spawn((Replicated, TestComponent));
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    assert_eq!(
+        remote_count(&mut client_app),
+        2,
+        "stale deferred updates must not survive disconnect"
+    );
+    assert_eq!(
+        client_app.world().resource::<ReceivedUserdata>().0,
+        1,
+        "only fresh userdata should be applied after reconnect"
+    );
+}
+
+#[test]
 fn deferred_mutation_is_acked_before_application() {
     let (mut server_app, mut client_app) = create_apps();
     client_app

--- a/tests/userdata.rs
+++ b/tests/userdata.rs
@@ -117,6 +117,7 @@ fn defer_update_message() {
         "userdata should be emitted only when its message is applied"
     );
 
+    // The policy accepts the userdata, so the update is applied.
     client_app.world_mut().resource_mut::<ReadyUserdata>().0 = USERDATA;
     client_app.update();
 
@@ -267,10 +268,16 @@ fn deferred_mutation_is_acked_before_application() {
 }
 
 #[test]
-fn malformed_mutation_is_not_acked() {
+fn deferred_update_holds_back_mutation() {
     let (mut server_app, mut client_app) = create_apps();
+    client_app
+        .world_mut()
+        .insert_resource(ReplicationApplyPolicy::new(apply_when_ready));
+    client_app.world_mut().resource_mut::<ReadyUserdata>().0 = 1;
     server_app.connect_client(&mut client_app);
 
+    // Defer the spawn update; it stays buffered and unapplied.
+    set_userdata(&mut server_app, 2);
     let server_entity = server_app
         .world_mut()
         .spawn((Replicated, ValueComponent(0)))
@@ -278,8 +285,11 @@ fn malformed_mutation_is_not_acked() {
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
-    server_app.exchange_with_client(&mut client_app);
+    assert_eq!(remote_count(&mut client_app), 0);
 
+    // The policy accepts this mutation's userdata, but its update is still deferred,
+    // so it must stay buffered until the update is applied.
+    set_userdata(&mut server_app, 1);
     server_app
         .world_mut()
         .get_mut::<ValueComponent>(server_entity)
@@ -287,32 +297,39 @@ fn malformed_mutation_is_not_acked() {
         .0 = 1;
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
-
-    {
-        let mut messages = client_app.world_mut().resource_mut::<ClientMessages>();
-        let malformed = messages
-            .iter_received(ServerChannel::Mutations)
-            .next()
-            .expect("server should send a mutation")
-            .slice(..3);
-        messages
-            .drain_received(ServerChannel::Mutations)
-            .for_each(drop);
-        messages.insert_received(ServerChannel::Mutations, malformed);
-    }
-
     client_app.update();
 
+    assert_eq!(
+        remote_count(&mut client_app),
+        0,
+        "a mutation must not pass its deferred update"
+    );
+    assert_eq!(
+        client_app.world().resource::<ReceivedUserdata>().0,
+        0,
+        "nothing should be applied while the update is deferred"
+    );
     assert!(
         client_app
             .world()
             .resource::<ClientMessages>()
             .iter_sent()
-            .all(
-                |(channel, bytes)| channel != usize::from(ClientChannel::MutationAcks)
-                    || bytes.is_empty()
+            .any(
+                |(channel, bytes)| channel == usize::from(ClientChannel::MutationAcks)
+                    && !bytes.is_empty()
             ),
-        "a mutation that could not be retained must not be acknowledged"
+        "a retained mutation should be acknowledged even while waiting for its update"
+    );
+
+    client_app.world_mut().resource_mut::<ReadyUserdata>().0 = 2;
+    client_app.update();
+
+    assert_eq!(remote_count(&mut client_app), 1);
+    assert_eq!(client_value(&mut client_app), 1);
+    assert_eq!(
+        client_app.world().resource::<ReceivedUserdata>().0,
+        1,
+        "messages should be applied in wire order once the update is ready"
     );
 }
 
@@ -342,16 +359,16 @@ fn set_userdata(app: &mut App, value: u32) {
     userdata.extend_from_slice(&value.to_le_bytes());
 }
 
-fn apply_when_ready(world: &World, message: ReplicationMessageInfo) -> ReplicationApplyDecision {
-    let Some(userdata) = message.userdata else {
-        return ReplicationApplyDecision::Apply;
+fn apply_when_ready(
+    world: &World,
+    _message_tick: RepliconTick,
+    userdata: Option<UserDataBytes>,
+) -> bool {
+    let Some(userdata) = userdata else {
+        return true;
     };
     let value = u32::from_le_bytes(userdata.try_into().expect("test userdata should be a u32"));
-    if value <= world.resource::<ReadyUserdata>().0 {
-        ReplicationApplyDecision::Apply
-    } else {
-        ReplicationApplyDecision::Defer
-    }
+    value <= world.resource::<ReadyUserdata>().0
 }
 
 fn remote_count(app: &mut App) -> usize {

--- a/tests/userdata.rs
+++ b/tests/userdata.rs
@@ -1,7 +1,10 @@
 use bevy::{prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{
-    client::UserdataReceived, prelude::*, server::ReplicationUserdata,
-    shared::backend::channels::ServerChannel, test_app::ServerTestAppExt,
+    client::UserdataReceived,
+    prelude::*,
+    server::ReplicationUserdata,
+    shared::backend::channels::{ClientChannel, ServerChannel},
+    test_app::ServerTestAppExt,
 };
 use serde::{Deserialize, Serialize};
 use test_log::test;
@@ -92,13 +95,250 @@ fn mutate_message() {
     assert_eq!(received.0, USERDATA);
 }
 
+#[test]
+fn defer_update_message() {
+    let (mut server_app, mut client_app) = create_apps();
+    client_app
+        .world_mut()
+        .insert_resource(ReplicationApplyPolicy::new(apply_when_ready));
+    server_app.connect_client(&mut client_app);
+
+    set_userdata(&mut server_app, USERDATA);
+    server_app.world_mut().spawn((Replicated, TestComponent));
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    assert_eq!(remote_count(&mut client_app), 0);
+    assert_eq!(
+        client_app.world().resource::<ReceivedUserdata>().0,
+        0,
+        "userdata should be emitted only when its message is applied"
+    );
+
+    client_app.world_mut().resource_mut::<ReadyUserdata>().0 = USERDATA;
+    client_app.update();
+
+    assert_eq!(remote_count(&mut client_app), 1);
+    assert_eq!(
+        client_app.world().resource::<ReceivedUserdata>().0,
+        USERDATA
+    );
+}
+
+#[test]
+fn deferred_update_blocks_later_updates() {
+    let (mut server_app, mut client_app) = create_apps();
+    client_app
+        .world_mut()
+        .insert_resource(ReplicationApplyPolicy::new(apply_when_ready));
+    client_app.world_mut().resource_mut::<ReadyUserdata>().0 = 1;
+    server_app.connect_client(&mut client_app);
+
+    set_userdata(&mut server_app, 2);
+    server_app.world_mut().spawn((Replicated, TestComponent));
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    set_userdata(&mut server_app, 1);
+    server_app.world_mut().spawn((Replicated, TestComponent));
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    assert_eq!(
+        client_app
+            .world()
+            .resource::<ClientMessages>()
+            .received_count(ServerChannel::Updates),
+        2
+    );
+    client_app.update();
+
+    assert_eq!(
+        remote_count(&mut client_app),
+        0,
+        "the ready second update must not pass the deferred first update"
+    );
+
+    client_app.world_mut().resource_mut::<ReadyUserdata>().0 = 2;
+    client_app.update();
+
+    assert_eq!(remote_count(&mut client_app), 2);
+    assert_eq!(
+        client_app.world().resource::<ReceivedUserdata>().0,
+        1,
+        "buffered updates should be applied in wire order"
+    );
+}
+
+#[test]
+fn deferred_mutation_is_acked_before_application() {
+    let (mut server_app, mut client_app) = create_apps();
+    client_app
+        .world_mut()
+        .insert_resource(ReplicationApplyPolicy::new(apply_when_ready));
+    server_app.connect_client(&mut client_app);
+
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, ValueComponent(0)))
+        .id();
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    server_app
+        .world_mut()
+        .get_mut::<ValueComponent>(server_entity)
+        .unwrap()
+        .0 = 1;
+    set_userdata(&mut server_app, USERDATA);
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    assert_eq!(client_value(&mut client_app), 0);
+    assert_eq!(client_app.world().resource::<ReceivedUserdata>().0, 0);
+    assert!(
+        client_app
+            .world()
+            .resource::<ClientMessages>()
+            .iter_sent()
+            .any(
+                |(channel, bytes)| channel == usize::from(ClientChannel::MutationAcks)
+                    && !bytes.is_empty()
+            ),
+        "a successfully retained mutation should be acknowledged before application"
+    );
+
+    client_app.world_mut().resource_mut::<ReadyUserdata>().0 = USERDATA;
+    client_app.update();
+
+    assert_eq!(client_value(&mut client_app), 1);
+    assert_eq!(
+        client_app.world().resource::<ReceivedUserdata>().0,
+        USERDATA
+    );
+}
+
+#[test]
+fn malformed_mutation_is_not_acked() {
+    let (mut server_app, mut client_app) = create_apps();
+    server_app.connect_client(&mut client_app);
+
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, ValueComponent(0)))
+        .id();
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    server_app
+        .world_mut()
+        .get_mut::<ValueComponent>(server_entity)
+        .unwrap()
+        .0 = 1;
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    {
+        let mut messages = client_app.world_mut().resource_mut::<ClientMessages>();
+        let malformed = messages
+            .iter_received(ServerChannel::Mutations)
+            .next()
+            .expect("server should send a mutation")
+            .slice(..3);
+        messages
+            .drain_received(ServerChannel::Mutations)
+            .for_each(drop);
+        messages.insert_received(ServerChannel::Mutations, malformed);
+    }
+
+    client_app.update();
+
+    assert!(
+        client_app
+            .world()
+            .resource::<ClientMessages>()
+            .iter_sent()
+            .all(
+                |(channel, bytes)| channel != usize::from(ClientChannel::MutationAcks)
+                    || bytes.is_empty()
+            ),
+        "a mutation that could not be retained must not be acknowledged"
+    );
+}
+
+fn create_apps() -> (App, App) {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .init_resource::<ReceivedUserdata>()
+        .init_resource::<ReadyUserdata>()
+        .add_observer(receive_userdata)
+        .replicate::<TestComponent>()
+        .replicate::<ValueComponent>()
+        .finish();
+    }
+
+    (server_app, client_app)
+}
+
+fn set_userdata(app: &mut App, value: u32) {
+    let mut userdata = app.world_mut().resource_mut::<ReplicationUserdata>();
+    userdata.clear();
+    userdata.extend_from_slice(&value.to_le_bytes());
+}
+
+fn apply_when_ready(world: &World, message: ReplicationMessageInfo) -> ReplicationApplyDecision {
+    let Some(userdata) = message.userdata else {
+        return ReplicationApplyDecision::Apply;
+    };
+    let value = u32::from_le_bytes(userdata.try_into().expect("test userdata should be a u32"));
+    if value <= world.resource::<ReadyUserdata>().0 {
+        ReplicationApplyDecision::Apply
+    } else {
+        ReplicationApplyDecision::Defer
+    }
+}
+
+fn remote_count(app: &mut App) -> usize {
+    app.world_mut()
+        .query_filtered::<Entity, With<Remote>>()
+        .iter(app.world())
+        .count()
+}
+
+fn client_value(app: &mut App) -> u32 {
+    app.world_mut()
+        .query::<&ValueComponent>()
+        .single(app.world())
+        .unwrap()
+        .0
+}
+
 const USERDATA: u32 = 42;
 
 #[derive(Component, Deserialize, Serialize)]
 struct TestComponent;
 
+#[derive(Component, Deserialize, Serialize)]
+struct ValueComponent(u32);
+
 #[derive(Resource, Default)]
 struct ReceivedUserdata(u32);
+
+#[derive(Resource, Default)]
+struct ReadyUserdata(u32);
 
 fn receive_userdata(received: On<UserdataReceived>, mut storage: ResMut<ReceivedUserdata>) {
     let bytes = received.bytes.as_ref().try_into().unwrap();

--- a/tests/userdata.rs
+++ b/tests/userdata.rs
@@ -42,7 +42,7 @@ fn update_message() {
     client_app.update();
 
     let received = client_app.world().resource::<ReceivedUserdata>();
-    assert_eq!(received.0, USERDATA);
+    assert_eq!(**received, Some(USERDATA));
 }
 
 #[test]
@@ -92,203 +92,11 @@ fn mutate_message() {
     client_app.update();
 
     let received = client_app.world().resource::<ReceivedUserdata>();
-    assert_eq!(received.0, USERDATA);
+    assert_eq!(**received, Some(USERDATA));
 }
 
 #[test]
-fn deferred_update_blocks_later_updates() {
-    let (mut server_app, mut client_app) = create_apps();
-    client_app.world_mut().resource_mut::<ReadyUserdata>().0 = 1;
-    server_app.connect_client(&mut client_app);
-
-    set_userdata(&mut server_app, 2);
-    server_app.world_mut().spawn((Replicated, TestComponent));
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-
-    set_userdata(&mut server_app, 1);
-    server_app.world_mut().spawn((Replicated, TestComponent));
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-
-    assert_eq!(
-        client_app
-            .world()
-            .resource::<ClientMessages>()
-            .received_count(ServerChannel::Updates),
-        2
-    );
-    client_app.update();
-
-    assert_eq!(
-        remote_count(&mut client_app),
-        0,
-        "the ready second update must not pass the deferred first update"
-    );
-
-    client_app.world_mut().resource_mut::<ReadyUserdata>().0 = 2;
-    client_app.update();
-
-    assert_eq!(remote_count(&mut client_app), 2);
-    assert_eq!(
-        client_app.world().resource::<ReceivedUserdata>().0,
-        1,
-        "buffered updates should be applied in wire order"
-    );
-}
-
-#[test]
-fn deferred_updates_cleared_on_disconnect() {
-    let (mut server_app, mut client_app) = create_apps();
-    server_app.connect_client(&mut client_app);
-
-    // Defer a spawn; it stays buffered and unapplied.
-    set_userdata(&mut server_app, USERDATA);
-    server_app.world_mut().spawn((Replicated, TestComponent));
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-    assert_eq!(remote_count(&mut client_app), 0);
-
-    // Disconnect runs the client reset, which must drop the deferred message.
-    server_app.disconnect_client(&mut client_app);
-    assert_eq!(remote_count(&mut client_app), 0);
-
-    // Reconnect with a policy that would still defer the stale message (`USERDATA` > 1).
-    // If it survived, it would head-of-line block the fresh state. The userdata is
-    // set before the handshake so handshake updates don't re-attach the stale value.
-    client_app.world_mut().resource_mut::<ReadyUserdata>().0 = 1;
-    set_userdata(&mut server_app, 1);
-    server_app.connect_client(&mut client_app);
-    server_app.world_mut().spawn((Replicated, TestComponent));
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-
-    assert_eq!(
-        remote_count(&mut client_app),
-        2,
-        "stale deferred updates must not survive disconnect"
-    );
-    assert_eq!(
-        client_app.world().resource::<ReceivedUserdata>().0,
-        1,
-        "only fresh userdata should be applied after reconnect"
-    );
-}
-
-#[test]
-fn deferred_mutation_is_acked_before_application() {
-    let (mut server_app, mut client_app) = create_apps();
-    server_app.connect_client(&mut client_app);
-
-    let server_entity = server_app
-        .world_mut()
-        .spawn((Replicated, ValueComponent(0)))
-        .id();
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-    server_app.exchange_with_client(&mut client_app);
-
-    server_app
-        .world_mut()
-        .get_mut::<ValueComponent>(server_entity)
-        .unwrap()
-        .0 = 1;
-    set_userdata(&mut server_app, USERDATA);
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-
-    assert_eq!(client_value(&mut client_app), 0);
-    assert_eq!(client_app.world().resource::<ReceivedUserdata>().0, 0);
-    assert!(
-        client_app
-            .world()
-            .resource::<ClientMessages>()
-            .iter_sent()
-            .any(
-                |(channel, bytes)| channel == usize::from(ClientChannel::MutationAcks)
-                    && !bytes.is_empty()
-            ),
-        "a successfully retained mutation should be acknowledged before application"
-    );
-
-    client_app.world_mut().resource_mut::<ReadyUserdata>().0 = USERDATA;
-    client_app.update();
-
-    assert_eq!(client_value(&mut client_app), 1);
-    assert_eq!(
-        client_app.world().resource::<ReceivedUserdata>().0,
-        USERDATA
-    );
-}
-
-#[test]
-fn deferred_update_holds_back_mutation() {
-    let (mut server_app, mut client_app) = create_apps();
-    client_app.world_mut().resource_mut::<ReadyUserdata>().0 = 1;
-    server_app.connect_client(&mut client_app);
-
-    // Defer the spawn update; it stays buffered and unapplied.
-    set_userdata(&mut server_app, 2);
-    let server_entity = server_app
-        .world_mut()
-        .spawn((Replicated, ValueComponent(0)))
-        .id();
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-    assert_eq!(remote_count(&mut client_app), 0);
-
-    // The observer accepts this mutation's userdata, but its update is still deferred,
-    // so it must stay buffered until the update is applied.
-    set_userdata(&mut server_app, 1);
-    server_app
-        .world_mut()
-        .get_mut::<ValueComponent>(server_entity)
-        .unwrap()
-        .0 = 1;
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-
-    assert_eq!(
-        remote_count(&mut client_app),
-        0,
-        "a mutation must not pass its deferred update"
-    );
-    assert_eq!(
-        client_app.world().resource::<ReceivedUserdata>().0,
-        0,
-        "nothing should be applied while the update is deferred"
-    );
-    assert!(
-        client_app
-            .world()
-            .resource::<ClientMessages>()
-            .iter_sent()
-            .any(
-                |(channel, bytes)| channel == usize::from(ClientChannel::MutationAcks)
-                    && !bytes.is_empty()
-            ),
-        "a retained mutation should be acknowledged even while waiting for its update"
-    );
-
-    client_app.world_mut().resource_mut::<ReadyUserdata>().0 = 2;
-    client_app.update();
-
-    assert_eq!(remote_count(&mut client_app), 1);
-    assert_eq!(client_value(&mut client_app), 1);
-    assert_eq!(
-        client_app.world().resource::<ReceivedUserdata>().0,
-        1,
-        "messages should be applied in wire order once the update is ready"
-    );
-}
-
-fn create_apps() -> (App, App) {
+fn deferred_update() {
     let mut server_app = App::new();
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
@@ -300,49 +108,125 @@ fn create_apps() -> (App, App) {
         .init_resource::<ReceivedUserdata>()
         .init_resource::<ReadyUserdata>()
         .add_observer(receive_userdata)
-        .replicate::<TestComponent>()
+        .finish();
+    }
+    client_app.add_observer(apply_when_ready);
+
+    server_app.connect_client(&mut client_app);
+
+    let mut userdata = server_app.world_mut().resource_mut::<ReplicationUserdata>();
+    userdata.extend_from_slice(&1u32.to_le_bytes());
+
+    server_app.world_mut().spawn((Replicated, TestComponent));
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let mut userdata = server_app.world_mut().resource_mut::<ReplicationUserdata>();
+    userdata.clear();
+    userdata.extend_from_slice(&0u32.to_le_bytes());
+
+    server_app.world_mut().spawn((Replicated, TestComponent));
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let updates_count = client_app
+        .world()
+        .resource::<ClientMessages>()
+        .received_count(ServerChannel::Updates);
+    assert_eq!(updates_count, 2);
+    client_app.update();
+
+    let mut remote = client_app.world_mut().query::<&Remote>();
+    assert_eq!(
+        remote.iter(client_app.world()).len(),
+        0,
+        "the ready second update must not pass the deferred first update"
+    );
+    assert!(client_app.world().resource::<ReceivedUserdata>().is_none());
+
+    **client_app.world_mut().resource_mut::<ReadyUserdata>() = 1;
+    client_app.update();
+
+    assert_eq!(remote.iter(client_app.world()).len(), 2);
+    assert_eq!(**client_app.world().resource::<ReceivedUserdata>(), Some(0));
+}
+
+#[test]
+fn deferred_mutation() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .init_resource::<ReceivedUserdata>()
+        .init_resource::<ReadyUserdata>()
+        .add_observer(receive_userdata)
         .replicate::<ValueComponent>()
         .finish();
     }
     client_app.add_observer(apply_when_ready);
 
-    (server_app, client_app)
-}
+    server_app.connect_client(&mut client_app);
 
-fn set_userdata(app: &mut App, value: u32) {
-    let mut userdata = app.world_mut().resource_mut::<ReplicationUserdata>();
+    // Defer the spawn update. It stays buffered and unapplied.
+    let mut userdata = server_app.world_mut().resource_mut::<ReplicationUserdata>();
+    userdata.extend_from_slice(&1u32.to_le_bytes());
+
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, ValueComponent(0)))
+        .id();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let mut remote = client_app.world_mut().query::<&Remote>();
+    assert_eq!(remote.iter(client_app.world()).len(), 0);
+    assert!(client_app.world().resource::<ReceivedUserdata>().is_none());
+
+    // The observer accepts this mutation's userdata, but its update is still deferred,
+    // so it must stay buffered until the update is applied.
+    let mut userdata = server_app.world_mut().resource_mut::<ReplicationUserdata>();
     userdata.clear();
-    userdata.extend_from_slice(&value.to_le_bytes());
-}
+    userdata.extend_from_slice(&0u32.to_le_bytes());
 
-fn apply_when_ready(mut trigger: On<ShouldApplyReplication>, ready: Res<ReadyUserdata>) {
-    let Some(userdata) = trigger.userdata.as_ref() else {
-        return;
-    };
-    let value = u32::from_le_bytes(
-        userdata
-            .as_ref()
-            .try_into()
-            .expect("test userdata should be a u32"),
+    let mut component = server_app
+        .world_mut()
+        .get_mut::<ValueComponent>(server_entity)
+        .unwrap();
+    **component = 1;
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    assert_eq!(remote.iter(client_app.world()).len(), 0);
+    assert_eq!(**client_app.world().resource::<ReceivedUserdata>(), Some(0));
+
+    let messages = client_app.world().resource::<ClientMessages>();
+    assert!(
+        messages
+            .iter_sent()
+            .any(|(c, _)| c == ClientChannel::MutationAcks as usize),
+        "a retained mutation should be acknowledged even while waiting for its update"
     );
-    if value > ready.0 {
-        trigger.should_apply = false;
-    }
-}
 
-fn remote_count(app: &mut App) -> usize {
-    app.world_mut()
-        .query_filtered::<Entity, With<Remote>>()
-        .iter(app.world())
-        .count()
-}
+    **client_app.world_mut().resource_mut::<ReadyUserdata>() = 1;
+    client_app.update();
 
-fn client_value(app: &mut App) -> u32 {
-    app.world_mut()
-        .query::<&ValueComponent>()
-        .single(app.world())
-        .unwrap()
-        .0
+    assert_eq!(
+        **client_app.world().resource::<ReceivedUserdata>(),
+        Some(1),
+        "messages should be applied in wire order once the update is ready"
+    );
+    assert_eq!(remote.iter(client_app.world()).len(), 1);
+
+    let mut components = client_app.world_mut().query::<&ValueComponent>();
+    assert_eq!(**components.single(client_app.world()).unwrap(), 1);
 }
 
 const USERDATA: u32 = 42;
@@ -350,16 +234,27 @@ const USERDATA: u32 = 42;
 #[derive(Component, Deserialize, Serialize)]
 struct TestComponent;
 
-#[derive(Component, Deserialize, Serialize)]
+#[derive(Component, Deref, DerefMut, Deserialize, Serialize)]
 struct ValueComponent(u32);
 
-#[derive(Resource, Default)]
-struct ReceivedUserdata(u32);
+#[derive(Resource, Deref, DerefMut, Default)]
+struct ReceivedUserdata(Option<u32>);
 
-#[derive(Resource, Default)]
+#[derive(Resource, Deref, DerefMut, Default)]
 struct ReadyUserdata(u32);
 
 fn receive_userdata(received: On<UserdataReceived>, mut storage: ResMut<ReceivedUserdata>) {
     let bytes = received.bytes.as_ref().try_into().unwrap();
-    storage.0 = u32::from_le_bytes(bytes);
+    storage.0 = Some(u32::from_le_bytes(bytes));
+}
+
+fn apply_when_ready(mut trigger: On<ShouldApplyReplication>, ready: Res<ReadyUserdata>) {
+    let Some(userdata) = &trigger.userdata else {
+        return;
+    };
+
+    let value = u32::from_le_bytes(userdata.as_ref().try_into().unwrap());
+    if value > ready.0 {
+        trigger.should_apply = false;
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/simgine/bevy_replicon/issues/736

Gives a way to separate **receiving** a message (receiving the bytes) from **applying** a message.
When a message is received, we check a user-provided ReplicationApplyPolicy that returns `true` if it can be applied immediately. If not, we buffer the message (either in BufferedUpdates and BufferedMutations).

Notes:
- we send an ack back on receive (so that the remote doesn't send the message again), but the confirm ticks (ServerMutateTicks, etc.) are only updated on application (since these are for the client to know what updates have been applied)
- updates are still applied in order
- mutations can still only be applied when all updates before it have been applied