### PR TITLE
Confirm mutate ticks after applying mutations

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -399,6 +399,7 @@ fn apply_mutate_message(
         mutate.flags, mutate.message_tick
     );
 
+    let mut messages_count = None;
     for (_, flag) in mutate.flags.iter_names() {
         match flag {
             MutateFlags::USERDATA => {
@@ -406,8 +407,10 @@ fn apply_mutate_message(
                     .map_err(|e| format!("unable to apply userdata: {e}"))?;
             }
             MutateFlags::MESSAGES_COUNT => {
-                confirm_mutate_tick(world, params.mutate_ticks, mutate)
-                    .map_err(|e| format!("unable to confirm mutate tick: {e}"))?;
+                messages_count = Some(
+                    postcard_utils::from_buf(&mut mutate.message)
+                        .map_err(|e| format!("unable to confirm mutate tick: {e}"))?,
+                );
             }
             MutateFlags::MUTATIONS => {
                 let len = apply_array(ArrayKind::Dynamic, &mut mutate.message, |message| {
@@ -420,6 +423,15 @@ fn apply_mutate_message(
             }
             _ => unreachable!("iteration should yield only named flags"),
         }
+    }
+
+    if let Some(messages_count) = messages_count {
+        confirm_mutate_tick(
+            world,
+            params.mutate_ticks,
+            mutate.message_tick,
+            messages_count,
+        );
     }
 
     Ok(())
@@ -710,17 +722,13 @@ fn confirm_tick(
 fn confirm_mutate_tick(
     world: &mut World,
     mutate_ticks: &mut ServerMutateTicks,
-    mutate: &mut BufferedMutate,
-) -> Result<()> {
-    let count = postcard_utils::from_buf(&mut mutate.message)?;
-    if mutate_ticks.confirm(mutate.message_tick, count) {
-        mutate_ticks.set_last_confirmed_tick(mutate.message_tick);
-        world.write_message(MutateTickReceived {
-            tick: mutate.message_tick,
-        });
+    tick: RepliconTick,
+    messages_count: usize,
+) {
+    if mutate_ticks.confirm(tick, messages_count) {
+        mutate_ticks.set_last_confirmed_tick(tick);
+        world.write_message(MutateTickReceived { tick });
     }
-
-    Ok(())
 }
 
 /// Deserializes and applies component mutations for an entity.

--- a/tests/mutate_ticks.rs
+++ b/tests/mutate_ticks.rs
@@ -3,13 +3,8 @@ use bevy_replicon::{
     client::server_mutate_ticks::{MutateTickReceived, ServerMutateTicks},
     prelude::*,
     server::server_tick::ServerTick,
-    shared::replication::{
-        deferred_entity::DeferredEntity,
-        registry::{ctx::WriteCtx, receive_fns},
-    },
     test_app::ServerTestAppExt,
 };
-use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use test_log::test;
 
@@ -191,91 +186,5 @@ fn multiple_messages() {
     assert_eq!(mutate_ticks.last_confirmed_tick(), Some(tick));
 }
 
-#[test]
-fn confirmation_follows_mutation_application() {
-    let mut server_app = App::new();
-    let mut client_app = App::new();
-    for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((
-            MinimalPlugins,
-            StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                track_mutate_messages: true,
-                ..ServerPlugin::new(PostUpdate)
-            }),
-        ))
-        .replicate::<BoolComponent>()
-        .set_receive_fns(
-            observe_confirmation,
-            receive_fns::default_remove::<BoolComponent>,
-        )
-        .finish();
-    }
-
-    server_app.connect_client(&mut client_app);
-    let server_entity = server_app
-        .world_mut()
-        .spawn((Replicated, BoolComponent(false)))
-        .id();
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app
-        .world_mut()
-        .resource_mut::<Messages<MutateTickReceived>>()
-        .clear();
-
-    server_app
-        .world_mut()
-        .get_mut::<BoolComponent>(server_entity)
-        .unwrap()
-        .0 = true;
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-
-    let tick = **server_app.world().resource::<ServerTick>();
-    let confirmation = client_app
-        .world_mut()
-        .query::<&ConfirmationObserved>()
-        .single(client_app.world())
-        .unwrap();
-    assert!(
-        !confirmation.0,
-        "the current mutation must not be confirmed while its write function runs"
-    );
-    assert_eq!(
-        client_app
-            .world()
-            .resource::<ServerMutateTicks>()
-            .last_confirmed_tick(),
-        Some(tick)
-    );
-}
-
 #[derive(Clone, Component, Copy, Deserialize, Serialize)]
 struct BoolComponent(bool);
-
-#[derive(Component)]
-struct ConfirmationObserved(bool);
-
-fn observe_confirmation(
-    ctx: &mut WriteCtx,
-    rule_fns: &RuleFns<BoolComponent>,
-    entity: &mut DeferredEntity,
-    message: &mut Bytes,
-) -> Result<()> {
-    let confirmed = unsafe {
-        !entity
-            .world_mut()
-            .resource::<Messages<MutateTickReceived>>()
-            .is_empty()
-    };
-    receive_fns::default_write(ctx, rule_fns, entity, message)?;
-    entity.insert(ConfirmationObserved(confirmed));
-
-    Ok(())
-}

--- a/tests/mutate_ticks.rs
+++ b/tests/mutate_ticks.rs
@@ -3,8 +3,13 @@ use bevy_replicon::{
     client::server_mutate_ticks::{MutateTickReceived, ServerMutateTicks},
     prelude::*,
     server::server_tick::ServerTick,
+    shared::replication::{
+        deferred_entity::DeferredEntity,
+        registry::{ctx::WriteCtx, receive_fns},
+    },
     test_app::ServerTestAppExt,
 };
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use test_log::test;
 
@@ -186,5 +191,91 @@ fn multiple_messages() {
     assert_eq!(mutate_ticks.last_confirmed_tick(), Some(tick));
 }
 
+#[test]
+fn confirmation_follows_mutation_application() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin {
+                track_mutate_messages: true,
+                ..ServerPlugin::new(PostUpdate)
+            }),
+        ))
+        .replicate::<BoolComponent>()
+        .set_receive_fns(
+            observe_confirmation,
+            receive_fns::default_remove::<BoolComponent>,
+        )
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, BoolComponent(false)))
+        .id();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app
+        .world_mut()
+        .resource_mut::<Messages<MutateTickReceived>>()
+        .clear();
+
+    server_app
+        .world_mut()
+        .get_mut::<BoolComponent>(server_entity)
+        .unwrap()
+        .0 = true;
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let tick = **server_app.world().resource::<ServerTick>();
+    let confirmation = client_app
+        .world_mut()
+        .query::<&ConfirmationObserved>()
+        .single(client_app.world())
+        .unwrap();
+    assert!(
+        !confirmation.0,
+        "the current mutation must not be confirmed while its write function runs"
+    );
+    assert_eq!(
+        client_app
+            .world()
+            .resource::<ServerMutateTicks>()
+            .last_confirmed_tick(),
+        Some(tick)
+    );
+}
+
 #[derive(Clone, Component, Copy, Deserialize, Serialize)]
 struct BoolComponent(bool);
+
+#[derive(Component)]
+struct ConfirmationObserved(bool);
+
+fn observe_confirmation(
+    ctx: &mut WriteCtx,
+    rule_fns: &RuleFns<BoolComponent>,
+    entity: &mut DeferredEntity,
+    message: &mut Bytes,
+) -> Result<()> {
+    let confirmed = unsafe {
+        !entity
+            .world_mut()
+            .resource::<Messages<MutateTickReceived>>()
+            .is_empty()
+    };
+    receive_fns::default_write(ctx, rule_fns, entity, message)?;
+    entity.insert(ConfirmationObserved(confirmed));
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

I confirm mutate ticks after the message's mutations are applied. Previously, a custom receive function could observe the message as confirmed before its mutation ran; now confirmation follows the writes.

Fixes #748

## Why

`ServerMutateTicks` now only reports ticks whose mutations have finished applying.

## Verification

- before, on current master: `cargo test --test mutate_ticks confirmation_follows_mutation_application` failed because the write function saw the current message confirmation
- after: `cargo test --test mutate_ticks confirmation_follows_mutation_application` passes
- `cargo test`
