### PR TITLE
Remove stale server mapping when reusing a client entity

### DIFF
--- a/src/shared/server_entity_map.rs
+++ b/src/shared/server_entity_map.rs
@@ -212,11 +212,12 @@ mod tests {
             map.to_client().get(&REPLACEMENT_SERVER_ENTITY),
             Some(&CLIENT_ENTITY)
         );
+
         assert_eq!(
             map.remove_by_client(CLIENT_ENTITY),
             Some(REPLACEMENT_SERVER_ENTITY)
         );
-        assert!(map.to_client().is_empty());
-        assert!(map.to_server().is_empty());
+        assert_eq!(map.server_entry(SERVER_ENTITY).get(), None);
+        assert!(!map.to_server().contains_key(&CLIENT_ENTITY));
     }
 }

--- a/src/shared/server_entity_map.rs
+++ b/src/shared/server_entity_map.rs
@@ -31,7 +31,12 @@ impl ServerEntityMap {
             }
         }
 
-        self.client_to_server.insert(client_entity, server_entity);
+        if let Some(existing_server_entity) =
+            self.client_to_server.insert(client_entity, server_entity)
+            && existing_server_entity != server_entity
+        {
+            self.server_to_client.remove(&existing_server_entity);
+        }
     }
 
     /// Returns server to client mappings.
@@ -167,6 +172,7 @@ mod tests {
     fn mapping() {
         const SERVER_ENTITY: Entity = Entity::from_raw_u32(0).unwrap();
         const CLIENT_ENTITY: Entity = Entity::from_raw_u32(1).unwrap();
+        const REPLACEMENT_SERVER_ENTITY: Entity = Entity::from_raw_u32(2).unwrap();
 
         let mut map = ServerEntityMap::default();
         assert_eq!(map.server_entry(SERVER_ENTITY).get(), None);
@@ -200,8 +206,17 @@ mod tests {
         );
         assert_eq!(map.server_entry(SERVER_ENTITY).get(), Some(CLIENT_ENTITY));
 
-        assert_eq!(map.remove_by_client(CLIENT_ENTITY), Some(SERVER_ENTITY));
-        assert_eq!(map.server_entry(SERVER_ENTITY).get(), None);
-        assert!(!map.to_server().contains_key(&CLIENT_ENTITY));
+        map.insert(REPLACEMENT_SERVER_ENTITY, CLIENT_ENTITY);
+        assert!(!map.to_client().contains_key(&SERVER_ENTITY));
+        assert_eq!(
+            map.to_client().get(&REPLACEMENT_SERVER_ENTITY),
+            Some(&CLIENT_ENTITY)
+        );
+        assert_eq!(
+            map.remove_by_client(CLIENT_ENTITY),
+            Some(REPLACEMENT_SERVER_ENTITY)
+        );
+        assert!(map.to_client().is_empty());
+        assert!(map.to_server().is_empty());
     }
 }

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -209,6 +209,52 @@ fn signature() {
 }
 
 #[test]
+fn signature_replacement() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let client_entity = client_app.world_mut().spawn(Signature::from(0)).id();
+    let old_server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, Signature::from(0)))
+        .id();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    server_app.world_mut().despawn(old_server_entity);
+    let new_server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, Signature::from(0)))
+        .id();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    assert!(client_app.world().get::<Remote>(client_entity).is_some());
+
+    let entity_map = client_app.world().resource::<ServerEntityMap>();
+    assert!(!entity_map.to_client().contains_key(&old_server_entity));
+    assert_eq!(
+        entity_map.to_server().get(&client_entity),
+        Some(&new_server_entity)
+    );
+}
+
+#[test]
 fn signature_with_hierarchy() {
     let mut server_app = App::new();
     let mut client_app = App::new();


### PR DESCRIPTION
Remove the stale server-to-client entry when reusing a client entity for a replacement server entity.

Fixes #757