### PR TITLE
Clean descendant mappings after recursive despawn

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -44,6 +44,7 @@ impl Plugin for ClientPlugin {
             .init_resource::<ServerUpdateTick>()
             .init_resource::<ServerMutateTicks>()
             .init_resource::<BufferedMutations>()
+            .init_resource::<BufferedRemoteDespawns>()
             .add_message::<EntityReplicated>()
             .add_message::<MutateTickReceived>()
             .configure_sets(
@@ -187,8 +188,20 @@ fn cleanup_storage(remove: On<Remove, Remote>, mut storage: If<ResMut<Replicatio
 // The server can despawn an entity without sending a replication message,
 // so we need to manually remove the entity from the `ServerEntityMap`
 // when it is despawned on the client.
-fn cleanup_entity_map(despawn: On<Despawn, Remote>, mut entity_map: If<ResMut<ServerEntityMap>>) {
-    entity_map.remove_by_client(despawn.entity);
+// During receive, only despawns caused by the authoritative handler are captured.
+fn cleanup_entity_map(
+    despawn: On<Despawn, Remote>,
+    entity_map: Option<ResMut<ServerEntityMap>>,
+    mut despawns: ResMut<BufferedRemoteDespawns>,
+) {
+    if let Some(mut entity_map) = entity_map {
+        entity_map.remove_by_client(despawn.entity);
+    } else if despawns
+        .capturing_root
+        .is_some_and(|root| root != despawn.entity)
+    {
+        despawns.entities.push(despawn.entity);
+    }
 }
 
 fn reset(
@@ -464,10 +477,21 @@ fn apply_despawn(
         params.signature_map.remove(client_entity);
         params.storage.entities.remove(&client_entity);
 
+        world
+            .resource_mut::<BufferedRemoteDespawns>()
+            .capturing_root = Some(client_entity);
         if let Ok(client_entity) = world.get_entity_mut(client_entity) {
             debug!("applying despawn for `{}`", client_entity.id());
             let ctx = DespawnCtx { message_tick };
             (params.registry.despawn)(&ctx, client_entity);
+        }
+
+        let mut despawns = world.resource_mut::<BufferedRemoteDespawns>();
+        despawns.capturing_root = None;
+        for client_entity in despawns.entities.drain(..) {
+            params.entity_map.remove_by_client(client_entity);
+            params.signature_map.remove(client_entity);
+            params.storage.entities.remove(&client_entity);
         }
     }
 
@@ -930,6 +954,13 @@ impl BufferedMutations {
             .partition_point(|other| mutate.message_tick.is_older(other.message_tick));
         self.0.insert(index, mutate);
     }
+}
+
+/// Remote entities despawned by an authoritative despawn handler.
+#[derive(Resource, Default)]
+struct BufferedRemoteDespawns {
+    capturing_root: Option<Entity>,
+    entities: Vec<Entity>,
 }
 
 /// Partially-deserialized mutate message that is waiting for its tick to appear in an update message.

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -121,6 +121,74 @@ fn with_relations() {
 }
 
 #[test]
+fn recursive_despawn_cleans_paused_child_mapping() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .replicate::<ChildOf>()
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let server_parent = server_app.world_mut().spawn(Replicated).id();
+    let server_child = server_app
+        .world_mut()
+        .spawn((Replicated, ChildOf(server_parent)))
+        .id();
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let client_child = *client_app
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_child)
+        .unwrap();
+
+    server_app
+        .world_mut()
+        .entity_mut(server_child)
+        .remove::<Replicated>();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    assert!(client_app.world().get_entity(client_child).is_ok());
+    {
+        let entity_map = client_app.world().resource::<ServerEntityMap>();
+        assert_eq!(
+            entity_map.to_client().get(&server_child),
+            Some(&client_child)
+        );
+        assert_eq!(
+            entity_map.to_server().get(&client_child),
+            Some(&server_child)
+        );
+    }
+
+    server_app.world_mut().despawn(server_parent);
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    assert!(client_app.world().get_entity(client_child).is_err());
+
+    let entity_map = client_app.world().resource::<ServerEntityMap>();
+    assert!(!entity_map.to_client().contains_key(&server_child));
+    assert!(!entity_map.to_server().contains_key(&client_child));
+}
+
+#[test]
 fn after_pause() {
     let mut server_app = App::new();
     let mut client_app = App::new();


### PR DESCRIPTION
Clean stale entity mappings, signatures, and replication storage for `Remote` descendants removed recursively by an authoritative despawn.

Capture is scoped to the despawn handler so predicted despawns retain their existing mapping behavior. Observing despawns directly also covers custom `linked_spawn` relationships.

Fixes #756