### PR TITLE
Handle despawns for entities that are not Replicating

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -199,7 +199,7 @@ fn cleanup_entity_map(
     if let Some(mut entity_map) = entity_map {
         entity_map.remove_by_client(despawn.entity);
     } else {
-        cascade.0.push(despawn.entity);
+        cascade.push(despawn.entity);
     }
 }
 
@@ -335,19 +335,17 @@ fn apply_update_message(
                 }
             }
             UpdateFlags::DESPAWNS => {
-                let result = apply_array(array_kind, message, |message| {
+                let len = apply_array(array_kind, message, |message| {
                     apply_despawn(world, params, message, message_tick)
                 })
-                .map_err(|e| format!("unable to apply despawns: {e}"));
+                .map_err(|e| format!("unable to apply despawns: {e}"))?;
                 // Despawns can cascade to other remote entities (e.g. children),
                 // which won't have their own despawn message.
-                let mut cascade = world.resource_mut::<DespawnCascade>();
-                for client_entity in cascade.drain(..) {
+                for client_entity in world.resource_mut::<DespawnCascade>().drain(..) {
                     params.entity_map.remove_by_client(client_entity);
                     params.signature_map.remove(client_entity);
                     params.storage.entities.remove(&client_entity);
                 }
-                let len = result?;
                 if let Some(stats) = &mut params.stats {
                     stats.despawns += len;
                 }
@@ -955,10 +953,8 @@ impl BufferedMutations {
     }
 }
 
-/// Remote entities despawned as part of an authoritative despawn cascade.
-///
-/// Collected by [`cleanup_entity_map`] while despawns are applied from a
-/// message and cleaned up after each despawn batch.
+/// Entities that were despawned during replication message processing
+/// and that need futured cleanup from the [`ServerEntityMap`] and [`SignatureMap`].
 #[derive(Resource, Default, Deref, DerefMut)]
 struct DespawnCascade(Vec<Entity>);
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -44,7 +44,7 @@ impl Plugin for ClientPlugin {
             .init_resource::<ServerUpdateTick>()
             .init_resource::<ServerMutateTicks>()
             .init_resource::<BufferedMutations>()
-            .init_resource::<DespawnCascade>()
+            .init_resource::<ReplicatedDespawns>()
             .add_message::<EntityReplicated>()
             .add_message::<MutateTickReceived>()
             .configure_sets(
@@ -188,18 +188,15 @@ fn cleanup_storage(remove: On<Remove, Remote>, mut storage: If<ResMut<Replicatio
 // The server can despawn an entity without sending a replication message,
 // so we need to manually remove the entity from the `ServerEntityMap`
 // when it is despawned on the client.
-// While despawns are applied from a message, the map is unavailable, so
-// cascaded despawns are collected into `DespawnCascade` for cleanup after
-// the batch.
 fn cleanup_entity_map(
     despawn: On<Despawn, Remote>,
     entity_map: Option<ResMut<ServerEntityMap>>,
-    mut cascade: ResMut<DespawnCascade>,
+    mut despawns: ResMut<ReplicatedDespawns>,
 ) {
     if let Some(mut entity_map) = entity_map {
         entity_map.remove_by_client(despawn.entity);
     } else {
-        cascade.push(despawn.entity);
+        despawns.push(despawn.entity);
     }
 }
 
@@ -209,7 +206,7 @@ fn reset(
     mut update_tick: ResMut<ServerUpdateTick>,
     mut entity_map: ResMut<ServerEntityMap>,
     mut buffered_mutations: ResMut<BufferedMutations>,
-    mut cascade: ResMut<DespawnCascade>,
+    mut despawns: ResMut<ReplicatedDespawns>,
     mutate_ticks: Option<ResMut<ServerMutateTicks>>,
     replication_stats: Option<ResMut<ClientReplicationStats>>,
 ) {
@@ -218,7 +215,7 @@ fn reset(
     *update_tick = Default::default();
     entity_map.clear();
     buffered_mutations.clear();
-    cascade.clear();
+    despawns.clear();
     if let Some(mut mutate_ticks) = mutate_ticks {
         mutate_ticks.clear();
     }
@@ -341,7 +338,7 @@ fn apply_update_message(
                 .map_err(|e| format!("unable to apply despawns: {e}"))?;
                 // Despawns can cascade to other remote entities (e.g. children),
                 // which won't have their own despawn message.
-                for client_entity in world.resource_mut::<DespawnCascade>().drain(..) {
+                for client_entity in world.resource_mut::<ReplicatedDespawns>().drain(..) {
                     params.entity_map.remove_by_client(client_entity);
                     params.signature_map.remove(client_entity);
                     params.storage.entities.remove(&client_entity);
@@ -480,11 +477,7 @@ fn apply_despawn(
     // with the last replication message, but the server might not yet have received confirmation
     // from the client and could include the deletion in the this message.
     let server_entity = postcard_utils::entity_from_buf(message)?;
-    if let Some(client_entity) = params.entity_map.server_entry(server_entity).remove() {
-        // Requires manual removal since these resources are removed from the world and inaccessible to observers.
-        params.signature_map.remove(client_entity);
-        params.storage.entities.remove(&client_entity);
-
+    if let Some(&client_entity) = params.entity_map.to_server().get(&server_entity) {
         if let Ok(client_entity) = world.get_entity_mut(client_entity) {
             debug!("applying despawn for `{}`", client_entity.id());
             let ctx = DespawnCtx { message_tick };
@@ -953,10 +946,16 @@ impl BufferedMutations {
     }
 }
 
-/// Entities that were despawned during replication message processing
-/// and that need futured cleanup from the [`ServerEntityMap`] and [`SignatureMap`].
+/// Entities that were despawned during replication message processing.
+///
+///
+/// When despawns are applied from a message, resources like
+/// [`ServerEntityMap`] or [`SignatureMap`] are unavailable.
+///
+/// So despawns are collected into this resource and cleaned up
+/// after applying all despawns.
 #[derive(Resource, Default, Deref, DerefMut)]
-struct DespawnCascade(Vec<Entity>);
+struct ReplicatedDespawns(Vec<Entity>);
 
 /// Partially-deserialized mutate message that is waiting for its tick to appear in an update message.
 ///

--- a/src/client.rs
+++ b/src/client.rs
@@ -476,12 +476,12 @@ fn apply_despawn(
     // with the last replication message, but the server might not yet have received confirmation
     // from the client and could include the deletion in the this message.
     let server_entity = postcard_utils::entity_from_buf(message)?;
-    if let Some(&client_entity) = params.entity_map.to_server().get(&server_entity) {
-        if let Ok(client_entity) = world.get_entity_mut(client_entity) {
-            debug!("applying despawn for `{}`", client_entity.id());
-            let ctx = DespawnCtx { message_tick };
-            (params.registry.despawn)(&ctx, client_entity);
-        }
+    if let Some(&client_entity) = params.entity_map.to_server().get(&server_entity)
+        && let Ok(client_entity) = world.get_entity_mut(client_entity)
+    {
+        debug!("applying despawn for `{}`", client_entity.id());
+        let ctx = DespawnCtx { message_tick };
+        (params.registry.despawn)(&ctx, client_entity);
     }
 
     Ok(())

--- a/src/client.rs
+++ b/src/client.rs
@@ -336,8 +336,7 @@ fn apply_update_message(
                     apply_despawn(world, params, message, message_tick)
                 })
                 .map_err(|e| format!("unable to apply despawns: {e}"))?;
-                // Despawns can cascade to other remote entities (e.g. children),
-                // which won't have their own despawn message.
+                // Update resources that are removed from the world.
                 for client_entity in world.resource_mut::<ReplicatedDespawns>().drain(..) {
                     params.entity_map.remove_by_client(client_entity);
                     params.signature_map.remove(client_entity);

--- a/src/client.rs
+++ b/src/client.rs
@@ -44,6 +44,7 @@ impl Plugin for ClientPlugin {
             .init_resource::<ServerUpdateTick>()
             .init_resource::<ServerMutateTicks>()
             .init_resource::<BufferedMutations>()
+            .init_resource::<DespawnCascade>()
             .add_message::<EntityReplicated>()
             .add_message::<MutateTickReceived>()
             .configure_sets(
@@ -187,8 +188,19 @@ fn cleanup_storage(remove: On<Remove, Remote>, mut storage: If<ResMut<Replicatio
 // The server can despawn an entity without sending a replication message,
 // so we need to manually remove the entity from the `ServerEntityMap`
 // when it is despawned on the client.
-fn cleanup_entity_map(despawn: On<Despawn, Remote>, mut entity_map: If<ResMut<ServerEntityMap>>) {
-    entity_map.remove_by_client(despawn.entity);
+// While despawns are applied from a message, the map is unavailable, so
+// cascaded despawns are collected into `DespawnCascade` for cleanup after
+// the batch.
+fn cleanup_entity_map(
+    despawn: On<Despawn, Remote>,
+    entity_map: Option<ResMut<ServerEntityMap>>,
+    mut cascade: ResMut<DespawnCascade>,
+) {
+    if let Some(mut entity_map) = entity_map {
+        entity_map.remove_by_client(despawn.entity);
+    } else {
+        cascade.0.push(despawn.entity);
+    }
 }
 
 fn reset(
@@ -197,6 +209,7 @@ fn reset(
     mut update_tick: ResMut<ServerUpdateTick>,
     mut entity_map: ResMut<ServerEntityMap>,
     mut buffered_mutations: ResMut<BufferedMutations>,
+    mut cascade: ResMut<DespawnCascade>,
     mutate_ticks: Option<ResMut<ServerMutateTicks>>,
     replication_stats: Option<ResMut<ClientReplicationStats>>,
 ) {
@@ -205,6 +218,7 @@ fn reset(
     *update_tick = Default::default();
     entity_map.clear();
     buffered_mutations.clear();
+    cascade.clear();
     if let Some(mut mutate_ticks) = mutate_ticks {
         mutate_ticks.clear();
     }
@@ -321,10 +335,19 @@ fn apply_update_message(
                 }
             }
             UpdateFlags::DESPAWNS => {
-                let len = apply_array(array_kind, message, |message| {
+                let result = apply_array(array_kind, message, |message| {
                     apply_despawn(world, params, message, message_tick)
                 })
-                .map_err(|e| format!("unable to apply despawns: {e}"))?;
+                .map_err(|e| format!("unable to apply despawns: {e}"));
+                // Despawns can cascade to other remote entities (e.g. children),
+                // which won't have their own despawn message.
+                let mut cascade = world.resource_mut::<DespawnCascade>();
+                for client_entity in cascade.drain(..) {
+                    params.entity_map.remove_by_client(client_entity);
+                    params.signature_map.remove(client_entity);
+                    params.storage.entities.remove(&client_entity);
+                }
+                let len = result?;
                 if let Some(stats) = &mut params.stats {
                     stats.despawns += len;
                 }
@@ -931,6 +954,13 @@ impl BufferedMutations {
         self.0.insert(index, mutate);
     }
 }
+
+/// Remote entities despawned as part of an authoritative despawn cascade.
+///
+/// Collected by [`cleanup_entity_map`] while despawns are applied from a
+/// message and cleaned up after each despawn batch.
+#[derive(Resource, Default, Deref, DerefMut)]
+struct DespawnCascade(Vec<Entity>);
 
 /// Partially-deserialized mutate message that is waiting for its tick to appear in an update message.
 ///

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -121,6 +121,144 @@ fn with_relations() {
 }
 
 #[test]
+fn recursive_despawn_cleans_paused_child_mapping() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .replicate::<ChildOf>()
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let server_parent = server_app.world_mut().spawn(Replicated).id();
+    let server_child = server_app
+        .world_mut()
+        .spawn((Replicated, ChildOf(server_parent)))
+        .id();
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let client_child = *client_app
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_child)
+        .unwrap();
+
+    server_app
+        .world_mut()
+        .entity_mut(server_child)
+        .remove::<Replicated>();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    assert!(client_app.world().get_entity(client_child).is_ok());
+    {
+        let entity_map = client_app.world().resource::<ServerEntityMap>();
+        assert_eq!(
+            entity_map.to_client().get(&server_child),
+            Some(&client_child)
+        );
+        assert_eq!(
+            entity_map.to_server().get(&client_child),
+            Some(&server_child)
+        );
+    }
+
+    server_app.world_mut().despawn(server_parent);
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    assert!(client_app.world().get_entity(client_child).is_err());
+
+    let entity_map = client_app.world().resource::<ServerEntityMap>();
+    assert!(!entity_map.to_client().contains_key(&server_child));
+    assert!(!entity_map.to_server().contains_key(&client_child));
+}
+
+#[test]
+fn recursive_despawn_cleans_paused_custom_relation_mapping() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .replicate::<MemberOf>()
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let server_parent = server_app.world_mut().spawn(Replicated).id();
+    let server_child = server_app
+        .world_mut()
+        .spawn((Replicated, MemberOf(server_parent)))
+        .id();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let client_parent = *client_app
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_parent)
+        .unwrap();
+    let client_child = *client_app
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_child)
+        .unwrap();
+    assert_eq!(
+        client_app.world().get::<MemberOf>(client_child).unwrap().0,
+        client_parent,
+        "hierarchy should replicate through the custom relationship"
+    );
+
+    server_app
+        .world_mut()
+        .entity_mut(server_child)
+        .remove::<Replicated>();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    assert!(client_app.world().get_entity(client_child).is_ok());
+
+    server_app.world_mut().despawn(server_parent);
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    assert!(client_app.world().get_entity(client_child).is_err());
+
+    let entity_map = client_app.world().resource::<ServerEntityMap>();
+    assert!(!entity_map.to_client().contains_key(&server_child));
+    assert!(!entity_map.to_server().contains_key(&client_child));
+}
+
+#[test]
 fn after_pause() {
     let mut server_app = App::new();
     let mut client_app = App::new();
@@ -465,6 +603,14 @@ fn with_visibility_gain_and_signature() {
 
 #[derive(Component, Deserialize, Serialize)]
 struct TestComponent;
+
+#[derive(Component, Deserialize, Serialize)]
+#[relationship(relationship_target = Members)]
+struct MemberOf(Entity);
+
+#[derive(Component)]
+#[relationship_target(relationship = MemberOf, linked_spawn)]
+struct Members(Vec<Entity>);
 
 #[derive(Resource, Deserialize, Serialize)]
 struct TestResource;

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -121,144 +121,6 @@ fn with_relations() {
 }
 
 #[test]
-fn recursive_despawn_cleans_paused_child_mapping() {
-    let mut server_app = App::new();
-    let mut client_app = App::new();
-    for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((
-            MinimalPlugins,
-            StatesPlugin,
-            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
-        ))
-        .replicate::<ChildOf>()
-        .finish();
-    }
-
-    server_app.connect_client(&mut client_app);
-
-    let server_parent = server_app.world_mut().spawn(Replicated).id();
-    let server_child = server_app
-        .world_mut()
-        .spawn((Replicated, ChildOf(server_parent)))
-        .id();
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-    server_app.exchange_with_client(&mut client_app);
-
-    let client_child = *client_app
-        .world()
-        .resource::<ServerEntityMap>()
-        .to_client()
-        .get(&server_child)
-        .unwrap();
-
-    server_app
-        .world_mut()
-        .entity_mut(server_child)
-        .remove::<Replicated>();
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-    server_app.exchange_with_client(&mut client_app);
-
-    assert!(client_app.world().get_entity(client_child).is_ok());
-    {
-        let entity_map = client_app.world().resource::<ServerEntityMap>();
-        assert_eq!(
-            entity_map.to_client().get(&server_child),
-            Some(&client_child)
-        );
-        assert_eq!(
-            entity_map.to_server().get(&client_child),
-            Some(&server_child)
-        );
-    }
-
-    server_app.world_mut().despawn(server_parent);
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-
-    assert!(client_app.world().get_entity(client_child).is_err());
-
-    let entity_map = client_app.world().resource::<ServerEntityMap>();
-    assert!(!entity_map.to_client().contains_key(&server_child));
-    assert!(!entity_map.to_server().contains_key(&client_child));
-}
-
-#[test]
-fn recursive_despawn_cleans_paused_custom_relation_mapping() {
-    let mut server_app = App::new();
-    let mut client_app = App::new();
-    for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((
-            MinimalPlugins,
-            StatesPlugin,
-            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
-        ))
-        .replicate::<MemberOf>()
-        .finish();
-    }
-
-    server_app.connect_client(&mut client_app);
-
-    let server_parent = server_app.world_mut().spawn(Replicated).id();
-    let server_child = server_app
-        .world_mut()
-        .spawn((Replicated, MemberOf(server_parent)))
-        .id();
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-    server_app.exchange_with_client(&mut client_app);
-
-    let client_parent = *client_app
-        .world()
-        .resource::<ServerEntityMap>()
-        .to_client()
-        .get(&server_parent)
-        .unwrap();
-    let client_child = *client_app
-        .world()
-        .resource::<ServerEntityMap>()
-        .to_client()
-        .get(&server_child)
-        .unwrap();
-    assert_eq!(
-        client_app.world().get::<MemberOf>(client_child).unwrap().0,
-        client_parent,
-        "hierarchy should replicate through the custom relationship"
-    );
-
-    server_app
-        .world_mut()
-        .entity_mut(server_child)
-        .remove::<Replicated>();
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-    server_app.exchange_with_client(&mut client_app);
-
-    assert!(client_app.world().get_entity(client_child).is_ok());
-
-    server_app.world_mut().despawn(server_parent);
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-
-    assert!(client_app.world().get_entity(client_child).is_err());
-
-    let entity_map = client_app.world().resource::<ServerEntityMap>();
-    assert!(!entity_map.to_client().contains_key(&server_child));
-    assert!(!entity_map.to_server().contains_key(&client_child));
-}
-
-#[test]
 fn after_pause() {
     let mut server_app = App::new();
     let mut client_app = App::new();
@@ -309,6 +171,77 @@ fn after_pause() {
     let entity_map = client_app.world().resource::<ServerEntityMap>();
     assert!(entity_map.to_client().is_empty());
     assert!(entity_map.to_server().is_empty());
+}
+
+#[test]
+fn after_pause_with_hierarchy() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .replicate::<ChildOf>()
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let server_parent = server_app.world_mut().spawn(Replicated).id();
+    let server_child = server_app
+        .world_mut()
+        .spawn((Replicated, ChildOf(server_parent)))
+        .id();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let client_child = *client_app
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_child)
+        .unwrap();
+
+    // Pause replication for child.
+    server_app
+        .world_mut()
+        .entity_mut(server_child)
+        .remove::<Replicated>();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    assert!(client_app.world().get_entity(client_child).is_ok());
+    let entity_map = client_app.world().resource::<ServerEntityMap>();
+    assert_eq!(
+        entity_map.to_client().get(&server_child),
+        Some(&client_child)
+    );
+    assert_eq!(
+        entity_map.to_server().get(&client_child),
+        Some(&server_child)
+    );
+
+    server_app.world_mut().despawn(server_parent);
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    assert!(client_app.world().get_entity(client_child).is_err());
+
+    let entity_map = client_app.world().resource::<ServerEntityMap>();
+    assert!(!entity_map.to_client().contains_key(&server_child));
+    assert!(
+        !entity_map.to_server().contains_key(&client_child),
+        "mapping should be removed even if the entity was paused"
+    );
 }
 
 #[test]
@@ -603,14 +536,6 @@ fn with_visibility_gain_and_signature() {
 
 #[derive(Component, Deserialize, Serialize)]
 struct TestComponent;
-
-#[derive(Component, Deserialize, Serialize)]
-#[relationship(relationship_target = Members)]
-struct MemberOf(Entity);
-
-#[derive(Component)]
-#[relationship_target(relationship = MemberOf, linked_spawn)]
-struct Members(Vec<Entity>);
 
 #[derive(Resource, Deserialize, Serialize)]
 struct TestResource;


### PR DESCRIPTION
During receive_replication, ServerEntityMap is removed so the observer could not despawn the entities. Instead we buffer these entities in a reousrce, so that we can despawn them later.

Fix https://github.com/simgine/bevy_replicon/issues/756